### PR TITLE
Fix to spatial flux lon/lon position relative to country borders

### DIFF
--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -213,10 +213,10 @@ def slice_flux(ds_all,start_date,end_date,
                     print(f'Scaling covariance units in {m} by {s_data[species]["units_scaling"][m0]**2}')
 
             # fix for flux scaling issue in ELRIS - to be removed once fixed in .nc files
-            if 'elris_old' in m:
-                for v in elris_scale:
-                    ds_all[m][v].values = ds_all[m][v].values/1e12
-                    print('Old ELRIS file! Applying additional scaling correction.')
+            #if 'elris_old' in m:
+            #    for v in elris_scale:
+            #        ds_all[m][v].values = ds_all[m][v].values/1e12
+            #        print('Old ELRIS file! Applying additional scaling correction.')
         
     return ds_all
 
@@ -533,9 +533,9 @@ def plot_obs_modelled_separate(ds_all,species,site,model_labels,
                   'uYmod':'model uncertainty',
                   'uYtotal':'total uncertainty'}
     var_colors = {'Yapriori':1,
-                  'Yapost':0,
+                  'Yapost':1,
                   'YaprioriBC':1,
-                  'YapostBC':0,
+                  'YapostBC':1,
                   'Ybias':0,
                   'YaprioriOUTER':1,
                   'YapostOUTER':0,
@@ -1600,11 +1600,7 @@ def plot_country_flux(ds_all,species,plot_regions,model_labels,
 
     if set_global_leg:
         handles, labels = ax[0,0].get_legend_handles_labels()
-        ncol=0
-        if plot_separate:
-            ncol=len(ds_all.keys())
-        if plot_combined:
-            ncol=ncol+3
+        ncol=len(ds_all.keys())
         if plot_inventory == True:
             ncol=ncol+1
         leg = fig.legend(handles, labels, loc='upper center',ncol=ncol,borderpad=.4,columnspacing=1.0,fontsize=10,bbox_to_anchor=(0.5, 1.07))
@@ -1794,23 +1790,23 @@ def plot_spatial_flux(ds_all,species,plot_area,model_labels,cmap=None,
                 ax2 = ax[2,i]
 
             ax0.pcolormesh(lon,lat,
-                            np.mean(ds_all[m]['flux_total_prior'][:,:-1,:-1],axis=0),cmap=cmap,
-                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='flat')
+                            np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0),cmap=cmap,
+                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='nearest')
 
             ax0.set_title(f'{model_labels[m]}: prior')
             
             ax1.pcolormesh(lon,lat,
-                            np.mean(ds_all[m]['flux_total_posterior'][:,:-1,:-1],axis=0),cmap=cmap,
-                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='flat')
+                            np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
+                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='nearest')
 
             ax1.set_title(f'{model_labels[m]}: posterior')
             
-            flux_diff = np.mean(ds_all[m]['flux_total_posterior'][:,:-1,:-1],axis=0)-np.mean(ds_all[m]['flux_total_prior'][:,:-1,:-1],axis=0)
+            flux_diff = np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0)-np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0)
             flux_diff[np.where(flux_diff) == np.nan] = 0.
             
             ax2.pcolormesh(lon,lat,
                             flux_diff,
-                            cmap=cmap_diff,vmin=difflim[species][0],vmax=difflim[species][1],shading='flat')
+                            cmap=cmap_diff,vmin=difflim[species][0],vmax=difflim[species][1],shading='nearest')
 
             ax2.set_title(f'{model_labels[m]}: posterior - prior')
             
@@ -2010,8 +2006,8 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,model_labels,
         elif i == 1:
             
             ax[1].pcolormesh(lon,lat,
-                            np.mean(ds_all[m]['flux_total_posterior'][:,:-1,:-1],axis=0),cmap=cmap,
-                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='flat')
+                            np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
+                            vmin=fluxlim[species][0],vmax=fluxlim[species][1],shading='nearest')
 
             ax[1].set_title(f'{model_labels[m]}\nPosterior mean')
             
@@ -2025,8 +2021,8 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,model_labels,
                 ax[2].scatter(sites_info[m][s]['longitude'],sites_info[m][s]['latitude'],color='white',
                             edgecolor='black',marker='o',s=30,zorder=2,alpha=0.8)
         
-    flux_diff = (np.mean(ds_all[all_keys[1]]['flux_total_posterior'].values[:,:-1,:-1],axis=0)-
-                 np.mean(ds_all[all_keys[0]]['flux_total_posterior'].values[:,:-1,:-1],axis=0))
+    flux_diff = (np.mean(ds_all[all_keys[1]]['flux_total_posterior'].values[:,:,:],axis=0)-
+                 np.mean(ds_all[all_keys[0]]['flux_total_posterior'].values[:,:,:],axis=0))
     flux_diff[np.where(flux_diff) == np.nan] = 0.
     
     ax[2].pcolormesh(lon,lat,
@@ -2254,13 +2250,13 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,model_labels,
                 time_out = (f'{start_print} - {end_print}')
 
             if var == 'posterior_prior_diff':
-                var_plot = np.mean(ds_all[m]['flux_total_posterior'][t0:t1+1,:-1,:-1],axis=0)-np.mean(ds_all[m]['flux_total_prior'][t0:t1+1,:-1,:-1],axis=0)
+                var_plot = np.mean(ds_all[m]['flux_total_posterior'][t0:t1+1,:,:],axis=0)-np.mean(ds_all[m]['flux_total_prior'][t0:t1+1,:,:],axis=0)
                 var_plot[np.where(var_plot) == np.nan] = 0.
             else:
-                var_plot = np.mean(ds_all[m][var][t0:t1+1,:-1,:-1],axis=0)
+                var_plot = np.mean(ds_all[m][var][t0:t1+1,:,:],axis=0)
 
             if n_cols == 1 and n_lines == 1:
-                ax.pcolormesh(lon,lat,var_plot,cmap=cmap,vmin=lim[0],vmax=lim[1],shading='flat')
+                ax.pcolormesh(lon,lat,var_plot,cmap=cmap,vmin=lim[0],vmax=lim[1],shading='nearest')
                 ax.set_title(f'{model_labels[m]}\n{time_out}')
             else:
                 if n_cols == 1:
@@ -2277,7 +2273,7 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,model_labels,
                     plot_title = f'{model_labels[m]}\n{time_out}'
                 else:
                     plot_title = f'{time_out}'
-                ax_var.pcolormesh(lon,lat,var_plot,cmap=cmap,vmin=lim[0],vmax=lim[1],shading='flat')
+                ax_var.pcolormesh(lon,lat,var_plot,cmap=cmap,vmin=lim[0],vmax=lim[1],shading='nearest')
                 ax_var.set_title(plot_title)
                 
             if plot_site_locations == True:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -533,9 +533,9 @@ def plot_obs_modelled_separate(ds_all,species,site,model_labels,
                   'uYmod':'model uncertainty',
                   'uYtotal':'total uncertainty'}
     var_colors = {'Yapriori':1,
-                  'Yapost':1,
+                  'Yapost':0,
                   'YaprioriBC':1,
-                  'YapostBC':1,
+                  'YapostBC':0,
                   'Ybias':0,
                   'YaprioriOUTER':1,
                   'YapostOUTER':0,
@@ -1600,7 +1600,11 @@ def plot_country_flux(ds_all,species,plot_regions,model_labels,
 
     if set_global_leg:
         handles, labels = ax[0,0].get_legend_handles_labels()
-        ncol=len(ds_all.keys())
+        ncol=0   
+        if plot_separate:
+            ncol=len(ds_all.keys())
+        if plot_combined:
+            ncol=ncol+3
         if plot_inventory == True:
             ncol=ncol+1
         leg = fig.legend(handles, labels, loc='upper center',ncol=ncol,borderpad=.4,columnspacing=1.0,fontsize=10,bbox_to_anchor=(0.5, 1.07))


### PR DESCRIPTION
The country borders and coastlines are plot assuming that the lat/lon arrays give the centre of the each grid cell.
So I've fixed the pcolormesh call which plots the grids of spatial fluxes so that it assumes the same coordinate setup. Before, pcolourmesh was assuming that the lat/lon arrays were giving the bottom left of each grid cell.

This moves fluxes half of one grid cell, and the prior fluxes now sit inside country borders as we'd expect.