### PR TITLE
Add missing species

### DIFF
--- a/species_info.json
+++ b/species_info.json
@@ -75,6 +75,25 @@
         "difflim":[-1e-11,1e-11]
         },     
 
+        "hfc152a":{
+            "species_print":"HFC-152a",
+            "period":"yearly",
+            "units_scaling":{"intem":1e6,
+                            "rhime":1e6,
+                            "elris":1e6},
+            "model_species":{"intem":"hfc152a",
+                            "rhime":"hfc152a",
+                            "elris":"HFC_152a"},
+            "units_print":"G",
+            "dt_units":{"intem":"datetime64[Y]",
+                        "rhime":"datetime64[Y]",
+                        "elris":"datetime64[Y]"},
+            "mf_units_scaling":1e-12,
+            "mf_units_print":"ppt",
+            "fluxlim":[0,1e-11],
+            "difflim":[-1e-11,1e-11]
+            },   
+
     "hfc32":{
         "species_print":"HFC-32",
         "period":"yearly",
@@ -131,6 +150,63 @@
         "fluxlim":[0,1e-12],
         "difflim":[-1e-12,1e-12]
     },
+
+    "hfc245fa":{
+        "species_print":"HFC-245fa",
+        "period":"yearly",
+        "units_scaling":{"intem":1e6,
+                        "rhime":1e6,
+                        "elris":1e6},
+        "model_species":{"intem":"hfc245fa",
+                        "rhime":"hfc245fa",
+                        "elris":"HFC_245fa"},
+        "units_print":"G",
+        "dt_units":{"intem":"datetime64[Y]",
+                    "rhime":"datetime64[Y]",
+                    "elris":"datetime64[Y]"},
+        "mf_units_scaling":1e-12,
+        "mf_units_print":"ppt",
+        "fluxlim":[0,1e-11],
+        "difflim":[-1e-11,1e-11]
+        },   
+
+    "hfc365mfc":{
+        "species_print":"HFC-365mfc",
+        "period":"yearly",
+        "units_scaling":{"intem":1e6,
+                        "rhime":1e6,
+                        "elris":1e6},
+        "model_species":{"intem":"hfc365mfc",
+                        "rhime":"hfc365mfc",
+                        "elris":"HFC_365mfc"},
+        "units_print":"G",
+        "dt_units":{"intem":"datetime64[Y]",
+                    "rhime":"datetime64[Y]",
+                    "elris":"datetime64[Y]"},
+        "mf_units_scaling":1e-12,
+        "mf_units_print":"ppt",
+        "fluxlim":[0,1e-11],
+        "difflim":[-1e-11,1e-11]
+        },
+
+    "hfc4310mee":{
+        "species_print":"HFC-4310mee",
+        "period":"yearly",
+        "units_scaling":{"intem":1e6,
+                        "rhime":1e6,
+                        "elris":1e6},
+        "model_species":{"intem":"hfc4310mee",
+                        "rhime":"hfc4310mee",
+                        "elris":"HFC_4310mee"},
+        "units_print":"G",
+        "dt_units":{"intem":"datetime64[Y]",
+                    "rhime":"datetime64[Y]",
+                    "elris":"datetime64[Y]"},
+        "mf_units_scaling":1e-12,
+        "mf_units_print":"ppt",
+        "fluxlim":[0,1e-11],
+        "difflim":[-1e-11,1e-11]
+        },   
 
     "pfc218":{
         "species_print":"PFC-218",


### PR DESCRIPTION
Add HFC-152a, 245fa, 365mfc, 4210mee to json file.
Default fluxlim and difflim were used. These might need to be later adapted.