### PR TITLE
New initialization function and other edits

### DIFF
--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -323,7 +323,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_together(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,s_data,m_data,annotate_coords,\n",
+    "                                    model_colors,s_data,m_data,annotate_coords,ppt_mode,\n",
     "                                    include=['Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)"
@@ -361,7 +361,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_diff(ds_all_mf_sliced,species,site,\n",
-    "                        model_colors,s_data,m_data,annotate_coords,\n",
+    "                        model_colors,s_data,m_data,annotate_coords,ppt_mode,\n",
     "                        include=['Yapost'],\n",
     "                        diff_include=['Yapost'],\n",
     "                        y_lim=None)"

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -93,7 +93,7 @@
     "ds_all_flux_scaled = {}\n",
     "\n",
     "if 'all' in species:\n",
-    "    ds_all_flux_scaled = func.read_flux_total_fgases(data_dir,species,models,s_data,\n",
+    "    ds_all_flux_scaled = func.read_flux_total_fgases(data_dir,species,models,s_data,m_data,\n",
     "                                                     regions,start_date,end_date,\n",
     "                                                     period_override=period_override)\n",
     "else:\n",

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -42,6 +42,9 @@
     "%autoreload 2\n",
     "import PARIS_inversion_results as func\n",
     "\n",
+    "s_data,m_data,m_colors = func.initialize_settings()\n",
+    "\n",
+    "### Path to results directory \n",
     "data_dir = '/project/paris/inverse_modelling/'\n",
     "\n",
     "### Group the models of interest in meaningful experiment names \n",
@@ -51,8 +54,8 @@
     "                                 'rhime_name_edgar','rhime_name_edgar_allobs'],\n",
     "               'elris_edgar'    :['elris_name_edgar','elris_name_edgar_allobs',              # Effect of transport model and obs selection (ELRIS only)\n",
     "                                  'elris_flex_edgar','elris_flex_edgar_allobs'],\n",
-    "               'wetcharts'      :['intem_33sites','elris_35sites_wetcharts',\n",
-    "                                  'rhime_36sites_wetcharts']\n",
+    "               'wetcharts'      :['intem_31sites_wetcharts','elris_31sites_wetcharts',\n",
+    "                                  'rhime_31sites_wetcharts']\n",
     "              }"
    ]
   },
@@ -90,18 +93,17 @@
     "ds_all_flux_scaled = {}\n",
     "\n",
     "if 'all' in species:\n",
-    "    ds_all_flux_scaled = func.read_flux_total_fgases(data_dir,species,models,\n",
+    "    ds_all_flux_scaled = func.read_flux_total_fgases(data_dir,species,models,s_data,\n",
     "                                                     regions,start_date,end_date,\n",
     "                                                     period_override=period_override)\n",
-    "    print('To change the files used as the standard for each HFC/PFC, edit the species_filename variable in PARIS_inversion_results.py')\n",
     "else:\n",
-    "    ds_all_flux = func.read_flux(data_dir,species,models,period_override=period_override)\n",
+    "    ds_all_flux = func.read_flux(data_dir,species,models,s_data,m_data,period_override=period_override)\n",
     "\n",
     "    for m in models:\n",
-    "        ds_all_flux_scaled[m] = func.slice_flux({m:ds_all_flux[m]},start_date,end_date,scale_units=True,\n",
+    "        ds_all_flux_scaled[m] = func.slice_flux({m:ds_all_flux[m]},start_date,end_date,s_data,scale_units=True,\n",
     "                                    species=species)[m]\n",
     "\n",
-    "model_colors = func.set_model_colors_2(models)"
+    "model_colors = func.set_model_colors_2(models,m_colors)"
    ]
   },
   {
@@ -134,7 +136,7 @@
     "###################################\n",
     "\n",
     "fig = func.plot_country_flux(ds_all_flux_scaled,species,regions,\n",
-    "                             model_colors,\n",
+    "                             s_data,m_data,model_colors,start_date,end_date,\n",
     "                             plot_inventory,inventory_years,data_dir,fix_y_axes,\n",
     "                             add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,\n",
     "                             plot_separate=plot_separate,plot_combined=plot_combined,\n",
@@ -210,13 +212,13 @@
     "###################################\n",
     "\n",
     "\n",
-    "ds_all_mf = func.read_mf(data_dir,species,models,period_override=period_override)\n",
+    "ds_all_mf = func.read_mf(data_dir,species,models,s_data,m_data,period_override=period_override)\n",
     "\n",
-    "ds_all_mf_sliced = func.slice_mf(ds_all_mf.copy(),start_date,end_date,site,baseline_site=baseline_site,\n",
+    "ds_all_mf_sliced = func.slice_mf(ds_all_mf.copy(),s_data,start_date,end_date,site,baseline_site=baseline_site,\n",
     "                              data_dir=data_dir,\n",
     "                              scale_units=True,species=species)\n",
     "\n",
-    "model_colors = func.set_model_colors_2(models)"
+    "model_colors = func.set_model_colors_2(models,m_colors)"
    ]
   },
   {
@@ -232,7 +234,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = func.plot_sites_timeseries(ds_all_mf,'Yapost',start_date,end_date,model_colors)\n",
+    "fig = func.plot_sites_timeseries(ds_all_mf,'Yapost',start_date,end_date,model_colors,m_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# output_path = '/project/paris/users/AlexDanjou/images/sites.png'\n",
     "\n",
     "# fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
@@ -252,7 +269,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_separate(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,\n",
+    "                                    model_colors,s_data,m_data,\n",
     "                                    include=['Yobs','Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)\n",
@@ -271,6 +288,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output_path = '/project/paris/users/AlexDanjou/images/Yapost_timeseries.png'\n",
+    "\n",
+    "# fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Timeseries plot, all models together:"
    ]
   },
@@ -281,10 +316,28 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_together(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,\n",
+    "                                    model_colors,s_data,m_data,\n",
     "                                    include=['Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output_path = '/project/paris/users/AlexDanjou/images/Yapost_allmodels.png'\n",
+    "\n",
+    "# fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
    ]
   },
   {
@@ -301,10 +354,28 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_diff(ds_all_mf_sliced,species,site,\n",
-    "                        model_colors,\n",
+    "                        model_colors,s_data,m_data,\n",
     "                        include=['Yapost'],\n",
     "                        diff_include=['Yapost'],\n",
     "                        y_lim=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output_path = '/project/paris/users/AlexDanjou/images/Yapost_diff.png'\n",
+    "\n",
+    "# fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
    ]
   },
   {
@@ -320,7 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_all_allsites = func.slice_mf(ds_all_mf.copy(),start_date,end_date,site=None,\n",
+    "ds_all_allsites = func.slice_mf(ds_all_mf.copy(),s_data,start_date,end_date,site=None,\n",
     "                              baseline_site=baseline_site,\n",
     "                              data_dir=data_dir,\n",
     "                              scale_units=True,species=species)\n",
@@ -328,7 +399,7 @@
     "pearson,nrmse = func.stats_mf(ds_all_allsites)\n",
     "\n",
     "fig = func.plot_stats_mf(pearson,nrmse,species,\n",
-    "                         model_colors,\n",
+    "                         model_colors,s_data,m_data,\n",
     "                         start_date=start_date,end_date=end_date)"
    ]
   },
@@ -374,15 +445,15 @@
     "period_override = None  #use to override standard inversion periods, must be a list the same length as models, e.g. ['monthly','yearly']\n",
     "###################################\n",
     "\n",
-    "ds_all_flux = func.read_flux(data_dir,species,models,period_override=period_override)\n",
+    "ds_all_flux = func.read_flux(data_dir,species,models,s_data,m_data,period_override=period_override)\n",
     "\n",
     "ds_all_flux_scaled = {}\n",
     "\n",
     "for m in models:\n",
-    "    ds_all_flux_scaled[m] = func.slice_flux({m:ds_all_flux[m]},start_date,end_date,scale_units=True,\n",
+    "    ds_all_flux_scaled[m] = func.slice_flux({m:ds_all_flux[m]},start_date,end_date,s_data,scale_units=True,\n",
     "                                species=species)[m]\n",
     "\n",
-    "model_colors = func.set_model_colors_2(models)"
+    "model_colors = func.set_model_colors_2(models,m_colors)"
    ]
   },
   {
@@ -409,11 +480,29 @@
     "season = None #If specified plot the seasonal mean (only valable for monthly data). Options for 'DJF', 'MAM', 'JJA' and 'SON'\n",
     "###################################\n",
     "\n",
-    "fig = func.plot_spatial_flux(ds_all_flux_scaled,species,plot_area,\n",
+    "fig = func.plot_spatial_flux(ds_all_flux_scaled,species,plot_area,s_data,m_data,\n",
     "                             cmap=cmap,cmap_diff=cmap_diff,c_border=c_border,\n",
     "                             period_override=period_override,plot_site_locations=plot_site_locations,\n",
     "                             plot_point_markers=plot_point_markers,\n",
     "                             season=season)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#output_path = None\n",
+    "\n",
+    "#fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
    ]
   },
   {
@@ -429,11 +518,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = func.plot_spatial_flux_comparison(ds_all_flux_scaled,species,plot_area,\n",
+    "fig = func.plot_spatial_flux_comparison(ds_all_flux_scaled,species,plot_area,s_data,m_data,\n",
     "                                        cmap=cmap,cmap_diff=cmap_diff,c_border=c_border,\n",
     "                                        period_override=period_override,\n",
     "                                        plot_site_locations=plot_site_locations,\n",
     "                                        plot_point_markers=plot_point_markers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#output_path = None\n",
+    "\n",
+    "#fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
    ]
   },
   {
@@ -463,11 +570,29 @@
     "plot_point_markers = ['paris','london'] #plot a marker at these locations, options for 'paris', 'london', 'nw_england' (PFC-218 source) or any value [lon,lat]\n",
     "###################################\n",
     "\n",
-    "fig = func.plot_spatial_flux_per_timestamp(ds_all_flux_scaled,species,plot_area,end_date,\n",
+    "fig = func.plot_spatial_flux_per_timestamp(ds_all_flux_scaled,species,plot_area,end_date,s_data,m_data,\n",
     "                                            cmap=cmap,c_border=c_border,\n",
     "                                            var=var,chop_by=chop_by,dt=dt,period_override=period_override,\n",
     "                                            plot_site_locations=plot_site_locations,\n",
     "                                            plot_point_markers=plot_point_markers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#output_path = None\n",
+    "\n",
+    "#fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
    ]
   },
   {
@@ -553,7 +678,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -55,8 +55,8 @@
     "                                 'rhime_name_edgar','rhime_name_edgar_allobs'],\n",
     "               'elris_edgar'    :['elris_name_edgar','elris_name_edgar_allobs',              # Effect of transport model and obs selection (ELRIS only)\n",
     "                                  'elris_flex_edgar','elris_flex_edgar_allobs'],\n",
-    "               'wetcharts'      :['intem_31sites_wetcharts','elris_31sites_wetcharts',\n",
-    "                                  'rhime_31sites_wetcharts']\n",
+    "               'wetcharts'      :['intem_name_wetcharts_31sites','elris_name_wetcharts_31sites',\n",
+    "                                  'rhime_name_wetcharts_31sites']\n",
     "              }\n",
     "\n",
     "###################################\n",
@@ -687,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -135,7 +135,7 @@
     "country_codes_as_titles = False #If True, lists 3-letter country codes under region names in subplot titles\n",
     "plot_separate = True #If True, includes all model results as separate lines\n",
     "plot_combined = False #If True, combined results, averaged from all models\n",
-    "resample = None #If None, no resample is done. Else resample the data to the given period ('QS-DEC' for seasonal average, 'YS' for yearly)\n",
+    "resample = None #If None, no resample is done. Else resample the data to the given period (options 'year' and 'season' for yearly and seasonal averages)\n",
     "plot_resample_and_original = False #If True, plots both the resampled and original data\n",
     "period_override = None #use to override standard inversion periods, must be a list the same length as models, e.g. ['monthly','yearly']\n",
     "###################################\n",

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "###################################\n",
     "\n",
-    "s_data,m_data,m_colors = func.initialize_settings(ppt_mode)"
+    "s_data,m_data,m_colors,annotate_coords = func.initialize_settings(ppt_mode)"
    ]
   },
   {
@@ -276,7 +276,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_separate(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,s_data,m_data,ppt_mode,\n",
+    "                                    model_colors,s_data,m_data,annotate_coords,ppt_mode,\n",
     "                                    include=['Yobs','Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)\n",
@@ -323,7 +323,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_together(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,s_data,m_data,\n",
+    "                                    model_colors,s_data,m_data,annotate_coords,\n",
     "                                    include=['Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)"
@@ -361,7 +361,7 @@
    "outputs": [],
    "source": [
     "fig = func.plot_obs_diff(ds_all_mf_sliced,species,site,\n",
-    "                        model_colors,s_data,m_data,\n",
+    "                        model_colors,s_data,m_data,annotate_coords,\n",
     "                        include=['Yapost'],\n",
     "                        diff_include=['Yapost'],\n",
     "                        y_lim=None)"

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -42,10 +42,11 @@
     "%autoreload 2\n",
     "import PARIS_inversion_results as func\n",
     "\n",
-    "s_data,m_data,m_colors = func.initialize_settings()\n",
-    "\n",
     "### Path to results directory \n",
     "data_dir = '/project/paris/inverse_modelling/'\n",
+    "\n",
+    "### Set ppt_mode to True for bigger fonts\n",
+    "ppt_mode = False\n",
     "\n",
     "### Group the models of interest in meaningful experiment names \n",
     "experiments = {'std_run'       :['intem_name_edgar','elris_name_edgar','rhime_name_edgar'], # Standard run \n",
@@ -56,7 +57,11 @@
     "                                  'elris_flex_edgar','elris_flex_edgar_allobs'],\n",
     "               'wetcharts'      :['intem_31sites_wetcharts','elris_31sites_wetcharts',\n",
     "                                  'rhime_31sites_wetcharts']\n",
-    "              }"
+    "              }\n",
+    "\n",
+    "###################################\n",
+    "\n",
+    "s_data,m_data,m_colors = func.initialize_settings(ppt_mode)"
    ]
   },
   {
@@ -136,7 +141,7 @@
     "###################################\n",
     "\n",
     "fig = func.plot_country_flux(ds_all_flux_scaled,species,regions,\n",
-    "                             s_data,m_data,model_colors,start_date,end_date,\n",
+    "                             s_data,m_data,model_colors,start_date,end_date,ppt_mode,\n",
     "                             plot_inventory,inventory_years,data_dir,fix_y_axes,\n",
     "                             add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,\n",
     "                             plot_separate=plot_separate,plot_combined=plot_combined,\n",
@@ -265,11 +270,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "fig = func.plot_obs_modelled_separate(ds_all_mf_sliced,species,site,\n",
-    "                                    model_colors,s_data,m_data,\n",
+    "                                    model_colors,s_data,m_data,ppt_mode,\n",
     "                                    include=['Yobs','Yapost'],\n",
     "                                    diff_include=['Yapost'],\n",
     "                                    y_lim=None)\n",
@@ -518,7 +525,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = func.plot_spatial_flux_comparison(ds_all_flux_scaled,species,plot_area,s_data,m_data,\n",
+    "fig = func.plot_spatial_flux_comparison(ds_all_flux_scaled,species,plot_area,s_data,m_data,ppt_mode,\n",
     "                                        cmap=cmap,cmap_diff=cmap_diff,c_border=c_border,\n",
     "                                        period_override=period_override,\n",
     "                                        plot_site_locations=plot_site_locations,\n",
@@ -553,7 +560,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "###################################\n",
@@ -678,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -1971,6 +1971,9 @@ def plot_country_flux(ds_all,species,plot_regions,
     elif len(plot_regions) < 4:
         n_cols = len(plot_regions)
         n_rows = 1
+    elif len(plot_regions) == 6:
+        n_cols = 3
+        n_rows = 2
     elif len(plot_regions) > 4:
         n_cols = 4
         n_rows = math.ceil(len(plot_regions)/4)

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -1704,6 +1704,7 @@ def extract_region_flux(ds_all,m,m0,country):
 #####################################################################
 
 def extract_region_inventory_flux(country,data_dir,species,
+                                  start_date,end_date,
                                   inventory_year=None):
     """
     Extracts inventory flux values for regions that exists,
@@ -1729,6 +1730,7 @@ def extract_region_inventory_flux(country,data_dir,species,
             inventory_time = None
 
     try:
+        inv_ds = inv_ds.sel(time=slice(start_date,end_date))
         inv_c_index = np.where(inv_ds['country'].values == country)[0][0]
         inventory_flux = inv_ds['inventory'].values[:,inv_c_index]/s_data[species]["units_scaling"]["intem"]
         inventory_time = inv_ds.time.values
@@ -1775,6 +1777,7 @@ def extract_region_inventory_flux(country,data_dir,species,
 
 def plot_country_flux(ds_all,species,plot_regions,
                       model_colors,
+                      start_date,end_date,
                       plot_inventory=True,inventory_years=None,
                       data_dir=None,fix_y_axes=False,
                       add_prior_unc=False, set_global_leg=False,
@@ -1794,6 +1797,9 @@ def plot_country_flux(ds_all,species,plot_regions,
             Gas species, e.g. 'ch4'.
         plot_regions (list of str):
             Country or regions to plot, e.g. ['UNITED KINGDOM','SWITZERLAND']
+        start_date (str) and end_date (str):
+            Start and end dates of the data to plot.
+            Used to slice inventory data.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
         plot_inventory (bool):
@@ -1859,7 +1865,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                                                       ds_all[m]['covariance_country_flux_total_posterior'].resample(time=resample).mean(dim="time")})
         
         else:
-            ds_all_p = ds_all
+            ds_all_p = ds_all.copy()
             
         del tmp
         
@@ -1922,6 +1928,7 @@ def plot_country_flux(ds_all,species,plot_regions,
             for y,i_year in enumerate(inventory_years):
             
                 inventory_flux,inventory_time = extract_region_inventory_flux(country,data_dir,species,
+                                                                              start_date,end_date,
                                                                               inventory_year=i_year)
                 
                 if inventory_flux is not None:
@@ -2009,7 +2016,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                                                 region_flux_total_prior_lower,
                                                 region_flux_total_prior_upper,
                                                 alpha=0.1,color=model_colors[m][0])
-                            max_cf.append(np.max(region_flux_total_prior_upper))
+                            max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_prior_upper)))
                             
                     
                     min_x.append(np.min(region_time).astype('datetime64[M]'))
@@ -2017,7 +2024,8 @@ def plot_country_flux(ds_all,species,plot_regions,
                     max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_posterior_upper)))
                     max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_prior)))
                     if plot_inventory == True:
-                        max_cf[i] = np.max((max_cf[i],np.nanmax(inventory_flux[np.logical_and(inventory_time >= np.min(region_time),
+                        if inventory_flux is not None:
+                            max_cf[i] = np.max((max_cf[i],np.nanmax(inventory_flux[np.logical_and(inventory_time >= np.min(region_time),
                                                                                         inventory_time <= np.max(region_time))])))
 
             if plot_combined == True:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -12,6 +12,7 @@ import cartopy
 from json import load
 import inspect
 from IPython.utils import io
+import sys
 
 model_q_indices = {'intem':[0,1],
                    'rhime':[0,1],
@@ -496,7 +497,6 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                  
                 if r == 0:
                     country_out = np.array([region])
-                    region_time_out = region_time
                     region_flux_total_posterior_out = np.expand_dims(region_flux_total_posterior,axis=1)
                     region_flux_total_prior_out = np.expand_dims(region_flux_total_prior,axis=1)
                     region_flux_total_posterior_lower_out = np.expand_dims(region_flux_total_posterior_lower,axis=1)
@@ -558,7 +558,7 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
         country_shortnames = []
         for c in ds_out_species_total['country_out'].values:
             try:
-                    country_shortnames.append(countrycodes_dict[c])
+                country_shortnames.append(countrycodes_dict[c])
             except:
                 country_shortnames.append(regions_dict_old[c])
                 
@@ -704,10 +704,6 @@ def slice_mf(ds_all,s_data,start_date=None,end_date=None,site=None,
             offset = int(np.mean(ds_all[m]['Yav'].values))
         else:
             offset = (ds_all[m].time.values[1].astype('datetime64[h]') - ds_all[m].time.values[0].astype('datetime64[h]')).astype(int)
-
-        # fix to move elris timestamps back to the middle of av period - to be removed once fixed in .nc files
-        if 'elris_old' in m:
-            ds_all[m]['time'] = ds_all[m]['time'] - np.timedelta64(offset,'h')/2
 
         # round seconds to integer (correction for elris)
         if 'elris' in m:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -443,7 +443,7 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                 ds_in[model] = None
                 if species not in missing_species[model]:
                     missing_species[model].append(species)
-                        
+
             for r,region in enumerate(regions):
                 
                 try:
@@ -585,7 +585,7 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
             print(f'\nAll species succesfully read for {model}!')
             
     for m in missing:
-        print(f'\nWARNING: Model {m} is missing species: {missing_species[model]}')
+        print(f'\nWARNING: Model {m} is missing species: {missing_species[m]}')
 
     print('\nTo change the files used as the standard for each HFC/PFC, edit variable std_run in species_info.json')
 

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -1359,6 +1359,8 @@ def plot_obs_modelled_together(ds_all,species,site,
         ax.xaxis.set_major_locator(YearLocator())
     else:
         ax.xaxis.set_major_locator(MonthLocator())
+        if (ppt_mode):
+            ax.tick_params(axis='x', rotation=70)
         
     if y_lim is None:
         ax.set_ylim([min(min_mf)-(0.02*min(min_mf)),
@@ -1580,6 +1582,8 @@ def plot_obs_diff(ds_all,species,site,
         ax.xaxis.set_major_locator(YearLocator())
     else:
         ax.xaxis.set_major_locator(MonthLocator())
+        if (ppt_mode):
+            ax.tick_params(axis='x', rotation=70)
         
     if y_lim is None:
         ax.set_ylim([min(min_mf)-(0.02*min(min_mf)),

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -58,10 +58,6 @@ regions_dict_old = {'CW_EU':'AUT-BEL-CHE-CZE-DEU-ESP-FRA-GBR-HRV-HUN-IRL-ITA-LUX
 
 countrycodes_dict.update(regions_dict)
 
-annotate_coords = {0:[0.6,0.80],
-                   1:[0.6,0.60],
-                   2:[0.6,0.40]}
-
 # population from 2018 to 2023 (at Jan 1 each year)
 bel_pop = np.array([11.399,11.455,11.522,11.555,11.618,11.723])
 lux_pop = np.array([0.602,0.614,0.626,0.635,0.645,0.661])
@@ -85,6 +81,8 @@ def initialize_settings(ppt_mode=False):
             Dictionary of inversion runs with filename and plot label (read from json file).
         model_colors (dict of lists):
             Default lists of colors to be used by each model.
+        annotate_coords (dict of lists):
+            Coordinates to annotate histogram.
     """
 
     ### read in species info file
@@ -120,7 +118,7 @@ def initialize_settings(ppt_mode=False):
                              ['limegreen','palegreen'],
                              ['olive','lightgreen']]}
 
-    ### font settings
+    ### font settings & annotate_coords
 
     if (ppt_mode):
         plt.rc('font', size=15)
@@ -130,9 +128,11 @@ def initialize_settings(ppt_mode=False):
         plt.rc('ytick', labelsize=15)
         plt.rc('legend', fontsize=14)
 
-        print('''WARNING: Using bigger fonts.
-         For the histograms, you will have to adapt the variable annotate_coords manually.
-         For the spatial maps, you might need to shrink the labels.''')
+        annotate_coords = {0:[0.58,0.65],
+                           1:[0.58,0.40],
+                           2:[0.58,0.15]}
+
+        print('WARNING: Using big fonts. You might need to shrink the labels.')
     else:
         plt.rc('font', size=12)
         plt.rc('axes', titlesize=12)
@@ -141,7 +141,11 @@ def initialize_settings(ppt_mode=False):
         plt.rc('ytick', labelsize=12)
         plt.rc('legend', fontsize=10)
 
-    return s_data,m_data,model_colors
+        annotate_coords = {0:[0.6,0.80],
+                           1:[0.6,0.60],
+                           2:[0.6,0.40]}
+
+    return s_data,m_data,model_colors,annotate_coords
 
 #####################################################################
 
@@ -874,7 +878,7 @@ def extract_site_info(sites):
 #####################################################################
 
 def plot_obs_modelled_separate(ds_all,species,site,
-                               model_colors,s_data,m_data,ppt_mode=False,
+                               model_colors,s_data,m_data,annotate_coords,ppt_mode=False,
                              include=['Yobs','Yapriori','Yapost'],
                              diff_include=['Yapriori','Yapost'],
                              add_unc=True,
@@ -899,6 +903,8 @@ def plot_obs_modelled_separate(ds_all,species,site,
             Dictionary of species with information for plotting (read from json file).
         m_data (dict of dict):
             Dictionary of inversion runs with filename and plot label (read from json file).
+        annotate_coords (dict of lists):
+            Coordinates to annotate histogram.
         ppt_mode (logical) (optional):
             If True, adjust annotation position to accomodate bigger fonts.
         include (list of str):
@@ -1137,7 +1143,7 @@ def plot_obs_modelled_separate(ds_all,species,site,
 #####################################################################
 
 def plot_obs_modelled_together(ds_all,species,site,
-                               model_colors,s_data,m_data,
+                               model_colors,s_data,m_data,annotate_coords,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                add_unc=True,
@@ -1162,6 +1168,8 @@ def plot_obs_modelled_together(ds_all,species,site,
             Dictionary of species with information for plotting (read from json file).
         m_data (dict of dict):
             Dictionary of inversion runs with filename and plot label (read from json file).
+        annotate_coords (dict of lists):
+            Coordinates to annotate histogram.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1366,7 +1374,7 @@ def plot_obs_modelled_together(ds_all,species,site,
 #####################################################################
 
 def plot_obs_diff(ds_all,species,site,
-                               model_colors,s_data,m_data,
+                               model_colors,s_data,m_data,annotate_coords,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                y_lim=None):
@@ -1392,6 +1400,8 @@ def plot_obs_diff(ds_all,species,site,
             Dictionary of species with information for plotting (read from json file).
         m_data (dict of dict):
             Dictionary of inversion runs with filename and plot label (read from json file).
+        annotate_coords (dict of lists):
+            Coordinates to annotate histogram.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -260,11 +260,11 @@ def read_flux(data_dir,species,models,s_data,m_data,period_override=None,verbose
                         ds_all[m] = in_ds
                     print('Done!')
                 else:
-                    print(f'Failed!')
-                    print(f'Cannot find {m} file for {species}. This data will not be included')
+                    print(f'\nFailed!')
+                    print(f'Cannot find {m} file for {species}. This data will not be included.')
             except:
                 print(f'Failed!')
-                print(f'Cannot find {m} file for {species}. This data will not be included')
+                print(f'Cannot find {m} file for {species}. This data will not be included.')
     
     return ds_all
 
@@ -429,10 +429,11 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                         ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
                 
                 except:
-                    print(f'No standard run file for {model} {species}, so looking for {model}_name_edgar')
-                    ds_in[model] = read_flux(data_dir,species,[f'{model}_name_edgar'],period_override[s])[f'{model}_name_edgar']    #edit read_flux so that it searches for correct filename per gas
+                    print(f'Looking for {model}_name_edgar.')
+                    ds_in[model] = read_flux(data_dir,species,[f'{model}_name_edgar'],s_data,m_data,period_override[s],verbose=False)[f'{model}_name_edgar']    #edit read_flux so that it searches for correct filename per gas
                     with io.capture_output() as captured:
-                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],scale_units=False,species=None)[model]
+                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
+                    print('Done!')
             except:
                 ds_in[model] = None
                 if species not in missing_species[model]:
@@ -443,7 +444,7 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                 try:
                     region_time,region_flux_total_posterior,region_flux_total_prior,\
                     region_flux_total_posterior_lower,region_flux_total_posterior_upper,\
-                    region_flux_total_prior_lower,region_flux_total_prior_upper = extract_region_flux(ds_in,model,m0,region)
+                    region_flux_total_prior_lower,region_flux_total_prior_upper = extract_region_flux(ds_in,model,m0,region,verbose=False)
                     
                     region_flux_total_posterior_lower[region_flux_total_posterior_lower < 0.] = 0.
                     region_flux_total_prior_lower[region_flux_total_prior_lower < 0.] = 0.
@@ -576,11 +577,13 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
     for model in models:
         if missing_species[model] != []:
             missing.append(model)
+        else:
+            print(f'\nAll species succesfully read for {model}!')
             
     for m in missing:
         print(f'\nWARNING: Model {m} is missing species: {missing_species[model]}')
 
-    print('To change the files used as the standard for each HFC/PFC, edit the species_filename variable in PARIS_inversion_results.py')
+    print('\nTo change the files used as the standard for each HFC/PFC, edit the species_filename variable in PARIS_inversion_results.py')
 
     return ds_all
     
@@ -1639,7 +1642,7 @@ def plot_stats_mf(pearson,nrmse,species,
 
 #####################################################################
 
-def extract_region_flux(ds_all,m,m0,country):
+def extract_region_flux(ds_all,m,m0,country,verbose=True):
     """
     Finds the index of a chosen region name and extracts the country flux
     variables for this region.
@@ -1661,8 +1664,8 @@ def extract_region_flux(ds_all,m,m0,country):
             try:
                 if m0 == 'intem' and country == 'BELGIUM':
                     country_search = 'BEL-LUX'
-                    print(f'\nNOTE: InTEM does not estimate separate BELGIUM emissions.')
-                    print(f'So a population ratio of {bel_pop_r} is being used to scale InTEM\'s total BELGIUM+LUXEMBOURG estimate.\n')
+                    if verbose: print(f'\nNOTE: InTEM does not estimate separate BELGIUM emissions.')
+                    if verbose: print(f'So a population ratio of {bel_pop_r} is being used to scale InTEM\'s total BELGIUM+LUXEMBOURG estimate.\n')
                     r = bel_pop_r
                 else:
                     country_search = countrycodes_dict[country]
@@ -1697,7 +1700,7 @@ def extract_region_flux(ds_all,m,m0,country):
         
         try:
             region_search = regions_dict[country]
-            print(f'{country} emissions are not present in {m}. Considering covariance matrix and sum of individual countries: {region_search}.')
+            if verbose: print(f'{country} emissions are not present in {m}. Considering covariance matrix and sum of individual countries: {region_search}.')
 
             country_list = region_search.split('-')
 

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -13,22 +13,13 @@ from json import load
 import inspect
 from IPython.utils import io
 
-model_colors = {'intem':[['navy','dodgerblue'],
-                         ['dodgerblue','skyblue']],
-                'elris':[['purple','mediumpurple'],
-                         ['deeppink','pink'],
-                         ['darkorange','red']],
-                'rhime':[['darkgreen','green'],
-                         ['limegreen','palegreen'],
-                         ['olive','lightgreen']]}
-
 model_q_indices = {'intem':[0,1],
                    'rhime':[0,1],
                    'elris':[0,1]}
 
 point_source_dict = {'paris':[2.340430,48.860050],
                      'london':[-0.127799,51.507593],
-                 'nw_england':[-2.796870,53.774820]}
+                     'nw_england':[-2.796870,53.774820]}
 
 countrycodes_dict = {'IRELAND':'IRL',
                      'UK':'GBR',
@@ -78,31 +69,60 @@ bel_pop_r = np.round(np.mean(bel_pop/(bel_pop+lux_pop)),3)
 font = {'size':12}
 plt.rc('font', **font)
 
-### read in species info file
+#####################################################################
 
-filename = os.path.join(os.getcwd(),'species_info.json')
+def initialize_settings():
+    """
+    Extracts species and models info from json files.
+    Defines standard colors for plotting.
 
-if os.path.exists(filename) == False:
-    print('ERROR: Cannot find species_info.json file. Check that this exists in the same directory as your notebook.')
+    Returns:
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
+        model_colors (dict of lists):
+            Default lists of colors to be used by each model.
+    """
 
-with open(filename, "r") as f:
-    s_data = load(f)
+    ### read in species info file
 
-### read in models info file
+    filename = os.path.join(os.getcwd(),'species_info.json')
 
-filename = os.path.join(os.getcwd(),'models_info.json')
+    if os.path.exists(filename) == False:
+        print('ERROR: Cannot find species_info.json file. Check that this exists in the same directory as your notebook.')
 
-if os.path.exists(filename) == False:
-    print('ERROR: Cannot find models_info.json file. Check that this exists in the same directory as your notebook.')
+    with open(filename, "r") as f:
+        s_data = load(f)
 
-with open(filename, "r") as f:
-    m_data = load(f)
+    ### read in models info file
 
-print('NOTE: If plotting units or scales look odd, edit species_info.json to fix this.')
+    filename = os.path.join(os.getcwd(),'models_info.json')
+
+    if os.path.exists(filename) == False:
+        print('ERROR: Cannot find models_info.json file. Check that this exists in the same directory as your notebook.')
+
+    with open(filename, "r") as f:
+        m_data = load(f)
+
+    print('NOTE: If plotting units or scales look odd, edit species_info.json to fix this.')
+
+    ### define colors
+
+    model_colors = {'intem':[['navy','dodgerblue'],
+                             ['dodgerblue','skyblue']],
+                    'elris':[['purple','mediumpurple'],
+                             ['deeppink','pink'],
+                             ['darkorange','red']],
+                    'rhime':[['darkgreen','green'],
+                             ['limegreen','palegreen'],
+                             ['olive','lightgreen']]}
+
+    return s_data,m_data,model_colors
 
 #####################################################################
 
-def set_model_colors(models):
+def set_model_colors(models,model_colors):
     cList = [['darkslateblue','dodgerblue'],
              ['red','lightsalmon'],
              ['green','lightgreen'],
@@ -118,13 +138,15 @@ def set_model_colors(models):
 
 #####################################################################
 
-def set_model_colors_2(models):
+def set_model_colors_2(models,model_colors):
     """
     Sets plotting colors for each model (updates model_colors).
 
     Args:
         models (list of str):
             Keys specifying model names, e.g. ['intem','elris']
+        model_colors (dict of lists):
+            Default lists of colors to be used by each model.
 
     Returns:
         mc (dict of lists):
@@ -171,7 +193,7 @@ def set_model_colors_2(models):
 
 #####################################################################
 
-def read_flux(data_dir,species,models,period_override=None):
+def read_flux(data_dir,species,models,s_data,m_data,period_override=None):
     """
     Extracts flux and country flux timeseries from each model.
     
@@ -182,6 +204,10 @@ def read_flux(data_dir,species,models,period_override=None):
             Gas species, e.g. 'ch4'.
         models (list of str): 
             Keys specifying model names, e.g. ['intem','elris']
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         period_override (list of str) (optional):
             Inversion periods to include, to override the standards in species_info.json.
             Must be the same length as models, e.g. ['monthly',None,'yearly']
@@ -242,7 +268,7 @@ def read_flux(data_dir,species,models,period_override=None):
 
 #####################################################################
 
-def slice_flux(ds_all,start_date,end_date,
+def slice_flux(ds_all,start_date,end_date,s_data,
                scale_units=True,species=None):
     """
     Slices the flux datasets to within given time limits and 
@@ -256,6 +282,8 @@ def slice_flux(ds_all,start_date,end_date,
         end_date (str): 
             Date to slice data to, e.g. '2022-01-01' would include all
             data up to 2021-12-31.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
         scale_units (bool): 
             If True, scales country fluxes to Tg or Gy per year.
         species (str):
@@ -300,7 +328,7 @@ def slice_flux(ds_all,start_date,end_date,
 
 #####################################################################
 
-def read_flux_total_fgases(data_dir,species,models,regions,
+def read_flux_total_fgases(data_dir,species,models,regions,s_data,
                            start_date,end_date,period_override=None):
     """
     Reads in fluxes from a list of gases and sums/averages totals and uncertainties,
@@ -316,6 +344,13 @@ def read_flux_total_fgases(data_dir,species,models,regions,
             Keys specifying model names, e.g. ['intem','elris']
         regions (list of str):
             Region names used to extract fluxes. Only these regions can then be plotted.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        start_date (str):
+            Date to slice data from, e.g. '2021-01-01'
+        end_date (str):
+            Date to slice data to, e.g. '2022-01-01' would include all
+            data up to 2021-12-31.
         period_override (list of str) (optional):
             Inversion periods to include, to override the standards in species_info.json.
             Must be the same length as models, e.g. ['monthly',None,'yearly']
@@ -542,12 +577,14 @@ def read_flux_total_fgases(data_dir,species,models,regions,
             
     for m in missing:
         print(f'\nWARNING: Model {m} is missing species: {missing_species[model]}')
-        
+
+    print('To change the files used as the standard for each HFC/PFC, edit the species_filename variable in PARIS_inversion_results.py')
+
     return ds_all
     
 #####################################################################
 
-def read_mf(data_dir,species,models,period_override=None):
+def read_mf(data_dir,species,models,s_data,m_data,period_override=None):
     """
     Extracts mole fraction timeseries data from each model.
     Args:
@@ -557,6 +594,10 @@ def read_mf(data_dir,species,models,period_override=None):
             Gas species, e.g. 'ch4'.
         models (list of str): 
             Keys specifying model names, e.g. ['intem','elris']
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         period_override (list of str) (optional):
             Inversion periods to include, to override the standards in species_info.json.
             Must be the same length as models, e.g. ['monthly',None,'yearly']
@@ -612,7 +653,7 @@ def read_mf(data_dir,species,models,period_override=None):
 
 #####################################################################
 
-def slice_mf(ds_all,start_date=None,end_date=None,site=None,
+def slice_mf(ds_all,s_data,start_date=None,end_date=None,site=None,
              baseline_site=None,data_dir=None,
              scale_units=False,
              species=None):
@@ -623,6 +664,8 @@ def slice_mf(ds_all,start_date=None,end_date=None,site=None,
     Args:
         ds_all (dictionary of datasets): 
             xarray datasets read directly from each model's flux netCDF.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
         start_date (str): 
             Date to slice data from, e.g. '2021-01-01'
         end_date (str): 
@@ -808,7 +851,7 @@ def extract_site_info(sites):
 #####################################################################
 
 def plot_obs_modelled_separate(ds_all,species,site,
-                               model_colors,
+                               model_colors,s_data,m_data,
                              include=['Yobs','Yapriori','Yapost'],
                              diff_include=['Yapriori','Yapost'],
                              add_unc=True,
@@ -829,6 +872,10 @@ def plot_obs_modelled_separate(ds_all,species,site,
             Obs site, e.g. 'MHD'.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1059,7 +1106,7 @@ def plot_obs_modelled_separate(ds_all,species,site,
 #####################################################################
 
 def plot_obs_modelled_together(ds_all,species,site,
-                               model_colors,
+                               model_colors,s_data,m_data,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                add_unc=True,
@@ -1080,6 +1127,10 @@ def plot_obs_modelled_together(ds_all,species,site,
             Obs site, e.g. 'MHD'.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1284,7 +1335,7 @@ def plot_obs_modelled_together(ds_all,species,site,
 #####################################################################
 
 def plot_obs_diff(ds_all,species,site,
-                               model_colors,
+                               model_colors,s_data,m_data,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                y_lim=None):
@@ -1306,6 +1357,10 @@ def plot_obs_diff(ds_all,species,site,
             Obs site, e.g. 'MHD'.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1499,7 +1554,7 @@ def plot_obs_diff(ds_all,species,site,
 #####################################################################
 
 def plot_stats_mf(pearson,nrmse,species,
-                  model_colors,
+                  model_colors,s_data,m_data,
                   start_date=None,end_date=None):
     """
     Plots fit statistics for all sites, for all models.
@@ -1513,6 +1568,10 @@ def plot_stats_mf(pearson,nrmse,species,
             Gas species, e.g. 'ch4'.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         start_date (str) and end_date (str):
             Dates used to title the plot. 
     Returns:
@@ -1704,7 +1763,7 @@ def extract_region_flux(ds_all,m,m0,country):
 #####################################################################
 
 def extract_region_inventory_flux(country,data_dir,species,
-                                  start_date,end_date,
+                                  s_data,start_date,end_date,
                                   inventory_year=None):
     """
     Extracts inventory flux values for regions that exists,
@@ -1776,7 +1835,7 @@ def extract_region_inventory_flux(country,data_dir,species,
 #####################################################################
 
 def plot_country_flux(ds_all,species,plot_regions,
-                      model_colors,
+                      s_data,m_data,model_colors,
                       start_date,end_date,
                       plot_inventory=True,inventory_years=None,
                       data_dir=None,fix_y_axes=False,
@@ -1797,6 +1856,10 @@ def plot_country_flux(ds_all,species,plot_regions,
             Gas species, e.g. 'ch4'.
         plot_regions (list of str):
             Country or regions to plot, e.g. ['UNITED KINGDOM','SWITZERLAND']
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         start_date (str) and end_date (str):
             Start and end dates of the data to plot.
             Used to slice inventory data.
@@ -1927,7 +1990,7 @@ def plot_country_flux(ds_all,species,plot_regions,
             
             for y,i_year in enumerate(inventory_years):
             
-                inventory_flux,inventory_time = extract_region_inventory_flux(country,data_dir,species,
+                inventory_flux,inventory_time = extract_region_inventory_flux(country,data_dir,species,s_data,
                                                                               start_date,end_date,
                                                                               inventory_year=i_year)
                 
@@ -2173,7 +2236,7 @@ def plot_country_flux(ds_all,species,plot_regions,
 
 #####################################################################
 
-def plot_spatial_flux(ds_all,species,plot_area,cmap=None,
+def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                       cmap_diff=None,c_border=None,period_override=None,
                       plot_site_locations=False,plot_point_markers=None,
                       season=None):
@@ -2194,6 +2257,10 @@ def plot_spatial_flux(ds_all,species,plot_area,cmap=None,
             Lat/lon region to plot, options for 'UK', 'FRANCE', 'GERMANY',
             'NWEU','CWEU','EUROPE'.
             A list with [min_lon, max_lon, min_lat, max_lat] can also be provided.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         cmap (str):
             Colour map for flux plots.
         cmap_diff (str):
@@ -2424,7 +2491,7 @@ def plot_spatial_flux(ds_all,species,plot_area,cmap=None,
 
 #####################################################################
 
-def plot_spatial_flux_comparison(ds_all,species,plot_area,
+def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,
                                  cmap=None,cmap_diff=None,c_border=None,period_override=None,
                                  plot_site_locations=False,plot_point_markers=None):
     """
@@ -2445,6 +2512,10 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,
         plot_area (str):
             Lat/lon region to plot, options for 'UK', 'FRANCE', 'GERMANY',
             'NWEU','CWEU'.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         cmap (str):
             Colour map for flux plots.
         cmap_diff (str):
@@ -2636,7 +2707,7 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,
 
 #####################################################################
 
-def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,
+def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_data,
                                     cmap='viridis',c_border='floralwhite',
                                     var='flux_total_posterior',
                                     chop_by='year',dt=1,period_override=None,
@@ -2657,6 +2728,10 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,
         end_date (str):
             End date of sliced data, e.g. '2022-01-01' would include all
             data up to 2021-12-31.
+        s_data (dict of dict):
+            Dictionary of species with information for plotting (read from json file).
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
         cmap (str):
             Colour map for flux plots.
         c_border (str):
@@ -2987,7 +3062,7 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,
 
 #####################################################################
 
-def plot_sites_timeseries(ds_all,var,start_date,end_date,model_colors):
+def plot_sites_timeseries(ds_all,var,start_date,end_date,model_colors,m_data):
     """
     Plot the timeseries of data available for each site and model.
     
@@ -3003,6 +3078,8 @@ def plot_sites_timeseries(ds_all,var,start_date,end_date,model_colors):
             data up to 2021-12-31.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
+        m_data (dict of dict):
+            Dictionary of inversion runs with filename and plot label (read from json file).
     """
     siteList = np.sort(np.unique(np.concatenate([ds_all[m].sitenames.values.astype(str) for m in ds_all.keys()])))
 

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -405,22 +405,6 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
               'To fix this error, set start_date and end_date as lists with the correct start and end times\nfor each model.')
         start_date = [start_date]*len(models)
         end_date = [end_date]*len(models)
-        
-    species_filenames = {'hfc134a':'name_edgar',
-                     'hfc143a':'name_edgar',
-                     'hfc125':'name_edgar',
-                     'hfc32':'name_edgar',
-                     'hfc23':'name_flat',
-                     'hfc152a':'name_flat',
-                     'hfc365mfc':'name_flat',
-                     'hfc4310mee':'name_flat',
-                     'hfc245fa':'name_flat',
-                     'hfc227ea':'name_flat',
-                     'pfc218':'name_flat',
-                     'pfc318':'name_flat',
-                     'pfc116':'name_edgarminval',
-                     'cf4':'name_edgarminval',
-                     'sf6':'name_flat'}
 
     if period_override == None:
         period_override = [None]*len(all_species)
@@ -431,11 +415,11 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
 
     for m,model in enumerate(models):
         
+        longrun = False
         if 'longrun' in model:
             model = model.split('_')[0]
             models[m] = model
-            for f in species_filenames.keys():
-                species_filenames[f] = f'{species_filenames[f]}_longrun'
+            longrun = True
 
         missing_species[model] = []
         m0 = model.split('_')[0]
@@ -446,21 +430,15 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
             #dictionary containing datasets for each species, these are then summed/averaged across the time coordinate
             ds_out = {}
             
-            #tries to read from standard filename, as listed above, if this fails, tries 'model_name_edgar', if this fails, skips this species
+            #tries to read from standard filename
             try:
-            
-                try:
-                    model_read = f'{model}_{species_filenames[species]}'
-                    ds_in[model] = read_flux(data_dir,species,[model_read],s_data,m_data,period_override[s],verbose=False)[model_read]    #edit read_flux so that it searches for correct filename per gas
-                    with io.capture_output() as captured:
-                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
+                model_read = f'{model}_{s_data[species]["std_run"][m0]}'
+                if longrun: model_read = f'{model_read}_longrun'
                 
-                except:
-                    print(f'Looking for {model}_name_edgar.')
-                    ds_in[model] = read_flux(data_dir,species,[f'{model}_name_edgar'],s_data,m_data,period_override[s],verbose=False)[f'{model}_name_edgar']    #edit read_flux so that it searches for correct filename per gas
-                    with io.capture_output() as captured:
-                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
-                    print('Done!')
+                ds_in[model] = read_flux(data_dir,species,[model_read],s_data,m_data,period_override[s],verbose=False)[model_read]    #edit read_flux so that it searches for correct filename per gas
+                with io.capture_output() as captured:
+                    ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
+
             except:
                 ds_in[model] = None
                 if species not in missing_species[model]:
@@ -609,7 +587,7 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
     for m in missing:
         print(f'\nWARNING: Model {m} is missing species: {missing_species[model]}')
 
-    print('\nTo change the files used as the standard for each HFC/PFC, edit the species_filename variable in PARIS_inversion_results.py')
+    print('\nTo change the files used as the standard for each HFC/PFC, edit variable std_run in species_info.json')
 
     return ds_all
     

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -323,7 +323,7 @@ def slice_flux(ds_all,start_date,end_date,s_data,
     skip_var = ['flux_total_prior','flux_total_posterior','percentile_flux_total_prior',
                 'percentile_flux_total_posterior','countryname','country',
                 'country_fraction','outer_region_fraction',
-                'covariance_country_flux_total_posterior']
+                'covariance_country_flux_total_posterior','flux_total_posterior_inversion_grid']
 
     for m in ds_all.keys():
         
@@ -2101,21 +2101,22 @@ def plot_country_flux(ds_all,species,plot_regions,
                                     region_flux_total_posterior,
                                     label=include_label,color=model_colors[m][0])
                         
-                        ax.plot(region_time,
-                                    region_flux_total_prior,
-                                    label=include_label_prior,color=model_colors[m][0],linestyle='dashed')
+                        if not(plot_combined):
+                            ax.plot(region_time,
+                                        region_flux_total_prior,
+                                        label=include_label_prior,color=model_colors[m][0],linestyle='dashed')
                         
-                        ax.fill_between(region_time,
-                                            region_flux_total_posterior_lower,
-                                            region_flux_total_posterior_upper,
-                                            alpha=0.3,color=model_colors[m][0])
-
-                        if add_prior_unc:
                             ax.fill_between(region_time,
-                                                region_flux_total_prior_lower,
-                                                region_flux_total_prior_upper,
-                                                alpha=0.1,color=model_colors[m][0])
-                            max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_prior_upper)))
+                                                region_flux_total_posterior_lower,
+                                                region_flux_total_posterior_upper,
+                                                alpha=0.3,color=model_colors[m][0])
+
+                            if add_prior_unc:
+                                ax.fill_between(region_time,
+                                                    region_flux_total_prior_lower,
+                                                    region_flux_total_prior_upper,
+                                                    alpha=0.1,color=model_colors[m][0])
+                                max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_prior_upper)))
                             
                     
                     min_x.append(np.min(region_time).astype('datetime64[M]'))
@@ -2160,7 +2161,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                 ax.fill_between(region_time.astype('datetime64[ns]'),
                                                 min_country_flux_total_lower,
                                                 max_country_flux_total_upper,
-                                                alpha=0.3,color='black',label='Min/max of post uncertainty')
+                                                alpha=0.3,color='grey',label='Min/max of post uncertainty')
                 '''
                 ax.plot(region_time.astype('datetime64[ns]'),
                                     pdf_mean,
@@ -2247,9 +2248,11 @@ def plot_country_flux(ds_all,species,plot_regions,
             ncol=0   
             if (plot_separate or resample):
                 ncol=len(ds_all.keys())
-            if plot_combined:
-                ncol=ncol+3
-            if plot_inventory == True:
+            if (plot_combined and plot_separate):
+                ncol=math.floor(len(ds_all.keys())/2)+2
+            elif plot_combined:
+                ncol=3
+            if plot_inventory:
                 ncol=ncol+1
             leg = fig.legend(handles, labels, loc='upper center',ncol=ncol,borderpad=.4,columnspacing=1.0,bbox_to_anchor=legend_loc)
             if plot_inventory == True:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -451,9 +451,6 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                     region_flux_total_posterior_lower,region_flux_total_posterior_upper,\
                     region_flux_total_prior_lower,region_flux_total_prior_upper = extract_region_flux(ds_in,model,m0,region,verbose=False)
                     
-                    region_flux_total_posterior_lower[region_flux_total_posterior_lower < 0.] = 0.
-                    region_flux_total_prior_lower[region_flux_total_prior_lower < 0.] = 0.
-                    
                     #for percentiles, first convert to upper and lower standard deviations (difference from mean)
                     region_flux_total_posterior_lower = (region_flux_total_posterior-region_flux_total_posterior_lower) * 1e3 * s_data[species]['gwp'] * 1e-12
                     region_flux_total_posterior_upper = (region_flux_total_posterior_upper-region_flux_total_posterior) * 1e3 * s_data[species]['gwp'] * 1e-12
@@ -1717,6 +1714,9 @@ def extract_region_flux(ds_all,m,m0,country,verbose=True):
         #print(region_time)
         #print(region_flux_total_posterior)
         
+        region_flux_total_posterior_lower[region_flux_total_posterior_lower < 0.] = 0.
+        region_flux_total_prior_lower[region_flux_total_prior_lower < 0.] = 0.
+
     #calculate values for region names that don't exist in the file
     except:
         
@@ -1773,6 +1773,9 @@ def extract_region_flux(ds_all,m,m0,country,verbose=True):
             region_flux_total_posterior_upper = region_flux_total_posterior + sigma_region_flux_total_posterior
             region_flux_total_prior_lower = region_flux_total_prior - sigma_region_flux_total_prior
             region_flux_total_prior_upper = region_flux_total_prior + sigma_region_flux_total_prior
+
+            region_flux_total_posterior_lower[region_flux_total_posterior_lower < 0.] = 0.
+            region_flux_total_prior_lower[region_flux_total_prior_lower < 0.] = 0.
 
         except:
             #print(f'ERROR: Could not find {country} emissions for {m}.')
@@ -1930,31 +1933,41 @@ def plot_country_flux(ds_all,species,plot_regions,
     
     # Create annual mean xarrays if needed
     if resample is not None:
+
+        # Check resample option
+        if (resample == 'year'):
+            rtime = 'YS'
+        elif (resample == 'season'):
+            rtime = 'QS-DEC'
+        else:
+            print(f'ERROR: Option resample=\'{resample}\' is not available. Try \'year\' or \'season\'.')
+            return None
+
         tmp = {m:ds_all[m].copy() for m in ds_all.keys()}
                 
         if period_override is not None: 
             for m in ds_all.keys():
                 if 'elris' in m:
                     del tmp[m]['covariance_country_flux_total_posterior']
-            ds_all_p = {m:tmp[m].resample(time=resample).mean(dim="time") if period_override[i] == 'monthly' else tmp[m] for i,m in enumerate(ds_all.keys())}
+            ds_all_p = {m:tmp[m].resample(time=rtime).mean(dim="time") if period_override[i] == 'monthly' else tmp[m] for i,m in enumerate(ds_all.keys())}
             for i,m in enumerate(ds_all.keys()):
                 if 'elris' in m and period_override[i] == 'monthly':
                     ds_all_p[m]['country'] = ds_all_p[m]['country'].isel(time=0).drop('time')
                     ds_all_p[m]['country_fraction'] = ds_all_p[m]['country_fraction'].isel(time=0).drop('time')
                     ds_all_p[m] = ds_all_p[m].assign({'covariance_country_flux_total_posterior':
-                                                      ds_all[m]['covariance_country_flux_total_posterior'].resample(time=resample).mean(dim="time")})
+                                                      ds_all[m]['covariance_country_flux_total_posterior'].resample(time=rtime).mean(dim="time")})
                     
         elif s_data[species]["period"]=='monthly':
             for m in ds_all.keys():
                 if 'elris' in m:
                     del tmp[m]['covariance_country_flux_total_posterior']
-            ds_all_p = {m:tmp[m].resample(time=resample).mean(dim="time") for m in ds_all.keys()}
+            ds_all_p = {m:tmp[m].resample(time=rtime).mean(dim="time") for m in ds_all.keys()}
             for m in ds_all.keys():
                 if 'elris' in m:
                     ds_all_p[m]['country'] = ds_all_p[m]['country'].isel(time=0).drop('time')
                     ds_all_p[m]['country_fraction'] = ds_all_p[m]['country_fraction'].isel(time=0).drop('time')
                     ds_all_p[m] = ds_all_p[m].assign({'covariance_country_flux_total_posterior':
-                                                      ds_all[m]['covariance_country_flux_total_posterior'].resample(time=resample).mean(dim="time")})
+                                                      ds_all[m]['covariance_country_flux_total_posterior'].resample(time=rtime).mean(dim="time")})
         
         else:
             ds_all_p = ds_all.copy()
@@ -2121,8 +2134,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                     max_cf[i] = np.max((max_cf[i],np.nanmax(region_flux_total_prior)))
                     if plot_inventory == True:
                         if inventory_flux is not None:
-                            max_cf[i] = np.max((max_cf[i],np.nanmax(inventory_flux[np.logical_and(inventory_time >= np.min(region_time),
-                                                                                        inventory_time <= np.max(region_time))])))
+                            max_cf[i] = np.nanmax((max_cf[i],np.nanmax(inventory_flux)))
 
             if plot_combined == True:
                 
@@ -2184,7 +2196,7 @@ def plot_country_flux(ds_all,species,plot_regions,
         
         ax.set_ylabel(f'{s_data[species]["species_print"]} ({s_data[species]["units_print"]}g y$^{{-1}}${y_label_append})')
         
-        if period_all[list(ds.keys())[0]] == 'monthly' and resample != 'YS':
+        if period_all[list(ds.keys())[0]] == 'monthly' and resample != 'year':
             ax.set_xlim([np.min(min_x)-np.timedelta64(1,'M'),
                             np.max(max_x)+np.timedelta64(1,'M')])
         else: #period_all[list(ds.keys())[0]] == 'yearly':

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -906,7 +906,7 @@ def plot_obs_modelled_separate(ds_all,species,site,
         annotate_coords (dict of lists):
             Coordinates to annotate histogram.
         ppt_mode (logical) (optional):
-            If True, adjust annotation position to accomodate bigger fonts.
+            If True, adjust annotation position and xlabel rotation to accomodate bigger fonts.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1143,7 +1143,7 @@ def plot_obs_modelled_separate(ds_all,species,site,
 #####################################################################
 
 def plot_obs_modelled_together(ds_all,species,site,
-                               model_colors,s_data,m_data,annotate_coords,
+                               model_colors,s_data,m_data,annotate_coords,ppt_mode=False,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                add_unc=True,
@@ -1170,6 +1170,8 @@ def plot_obs_modelled_together(ds_all,species,site,
             Dictionary of inversion runs with filename and plot label (read from json file).
         annotate_coords (dict of lists):
             Coordinates to annotate histogram.
+        ppt_mode (logical) (optional):
+            If True, adjust xlabel rotation to accomodate bigger fonts.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1376,7 +1378,7 @@ def plot_obs_modelled_together(ds_all,species,site,
 #####################################################################
 
 def plot_obs_diff(ds_all,species,site,
-                               model_colors,s_data,m_data,annotate_coords,
+                               model_colors,s_data,m_data,annotate_coords,ppt_mode=False,
                                include=['Yapost'],
                                diff_include=['Yapost'],
                                y_lim=None):
@@ -1404,6 +1406,8 @@ def plot_obs_diff(ds_all,species,site,
             Dictionary of inversion runs with filename and plot label (read from json file).
         annotate_coords (dict of lists):
             Coordinates to annotate histogram.
+        ppt_mode (logical) (optional):
+            If True, adjust xlabel rotation to accomodate bigger fonts.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -193,7 +193,7 @@ def set_model_colors_2(models,model_colors):
 
 #####################################################################
 
-def read_flux(data_dir,species,models,s_data,m_data,period_override=None):
+def read_flux(data_dir,species,models,s_data,m_data,period_override=None,verbose=True):
     """
     Extracts flux and country flux timeseries from each model.
     
@@ -211,6 +211,8 @@ def read_flux(data_dir,species,models,s_data,m_data,period_override=None):
         period_override (list of str) (optional):
             Inversion periods to include, to override the standards in species_info.json.
             Must be the same length as models, e.g. ['monthly',None,'yearly']
+        verbose (logical) (optional):
+            If True, print execution tracking messages.
                                        
     Returns:
         ds_all (dictionary of datasets): 
@@ -235,7 +237,7 @@ def read_flux(data_dir,species,models,s_data,m_data,period_override=None):
     ds_all = {}
 
     for m in models:
-        print(f'\nAttempting to read data from {m}')
+        if verbose: print(f'\nAttempting to read data from {m}')
         
         m0 = m.split('_')[0]
         
@@ -244,10 +246,10 @@ def read_flux(data_dir,species,models,s_data,m_data,period_override=None):
         try:
             filepath = glob.glob(os.path.join(data_dir,model_dir,species,
                                               f'{m_data[m]["filename"]}_{s_data[species]["model_species"][m0]}_{period_all[m]}.nc'))
-            print(f'Reading data from: {filepath[0]}')
+            if verbose: print(f'Reading data from: {filepath[0]}')
             with xr.open_dataset(filepath[0]) as in_ds:
                 ds_all[m] = in_ds
-                print('Done!')
+                if verbose: print('Done!')
         except:
             try:
                 if (m_data[m]["filename"].split('_')[-1] == 'std*'):
@@ -328,7 +330,7 @@ def slice_flux(ds_all,start_date,end_date,s_data,
 
 #####################################################################
 
-def read_flux_total_fgases(data_dir,species,models,regions,s_data,
+def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
                            start_date,end_date,period_override=None):
     """
     Reads in fluxes from a list of gases and sums/averages totals and uncertainties,
@@ -422,9 +424,9 @@ def read_flux_total_fgases(data_dir,species,models,regions,s_data,
             
                 try:
                     model_read = f'{model}_{species_filenames[species]}'
-                    ds_in[model] = read_flux(data_dir,species,[model_read],period_override[s])[model_read]    #edit read_flux so that it searches for correct filename per gas
+                    ds_in[model] = read_flux(data_dir,species,[model_read],s_data,m_data,period_override[s],verbose=False)[model_read]    #edit read_flux so that it searches for correct filename per gas
                     with io.capture_output() as captured:
-                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],scale_units=False,species=None)[model]
+                        ds_in[model] = slice_flux(ds_in,start_date[m],end_date[m],s_data,scale_units=False,species=None)[model]
                 
                 except:
                     print(f'No standard run file for {model} {species}, so looking for {model}_name_edgar')
@@ -557,7 +559,7 @@ def read_flux_total_fgases(data_dir,species,models,regions,s_data,
             try:
                     country_shortnames.append(countrycodes_dict[c])
             except:
-                country_shortnames.append(regions_dict_old[country])
+                country_shortnames.append(regions_dict_old[c])
                 
         ds_all[model] = xr.Dataset({'country_flux_total_prior':(['time',country_coord_name],ds_out_species_total['region_flux_total_prior_out'].values),
                                     'country_flux_total_posterior':(['time',country_coord_name],ds_out_species_total['region_flux_total_posterior_out'].values),

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -67,15 +67,16 @@ bel_pop = np.array([11.399,11.455,11.522,11.555,11.618,11.723])
 lux_pop = np.array([0.602,0.614,0.626,0.635,0.645,0.661])
 bel_pop_r = np.round(np.mean(bel_pop/(bel_pop+lux_pop)),3)
 
-font = {'size':12}
-plt.rc('font', **font)
-
 #####################################################################
 
-def initialize_settings():
+def initialize_settings(ppt_mode=False):
     """
     Extracts species and models info from json files.
     Defines standard colors for plotting.
+
+    Args:
+        ppt_mode (logical) (optional):
+            If True, use bigger fonts (ideal for presentation slides)
 
     Returns:
         s_data (dict of dict):
@@ -118,6 +119,27 @@ def initialize_settings():
                     'rhime':[['darkgreen','green'],
                              ['limegreen','palegreen'],
                              ['olive','lightgreen']]}
+
+    ### font settings
+
+    if (ppt_mode):
+        plt.rc('font', size=15)
+        plt.rc('axes', titlesize=18)
+        plt.rc('axes', labelsize=16)
+        plt.rc('xtick', labelsize=15)
+        plt.rc('ytick', labelsize=15)
+        plt.rc('legend', fontsize=14)
+
+        print('''WARNING: Using bigger fonts.
+         For the histograms, you will have to adapt the variable annotate_coords manually.
+         For the spatial maps, you might need to shrink the labels.''')
+    else:
+        plt.rc('font', size=12)
+        plt.rc('axes', titlesize=12)
+        plt.rc('axes', labelsize=12)
+        plt.rc('xtick', labelsize=12)
+        plt.rc('ytick', labelsize=12)
+        plt.rc('legend', fontsize=10)
 
     return s_data,m_data,model_colors
 
@@ -852,7 +874,7 @@ def extract_site_info(sites):
 #####################################################################
 
 def plot_obs_modelled_separate(ds_all,species,site,
-                               model_colors,s_data,m_data,
+                               model_colors,s_data,m_data,ppt_mode=False,
                              include=['Yobs','Yapriori','Yapost'],
                              diff_include=['Yapriori','Yapost'],
                              add_unc=True,
@@ -877,6 +899,8 @@ def plot_obs_modelled_separate(ds_all,species,site,
             Dictionary of species with information for plotting (read from json file).
         m_data (dict of dict):
             Dictionary of inversion runs with filename and plot label (read from json file).
+        ppt_mode (logical) (optional):
+            If True, adjust annotation position to accomodate bigger fonts.
         include (list of str):
             Variables included in the plot, options for 'Yobs', 'Yapriori',
             'Yapost', 'YaprioriBC', 'YapostBC'.
@@ -1067,7 +1091,11 @@ def plot_obs_modelled_separate(ds_all,species,site,
 
         # Write number of obs to plot
         n_obs = (~np.isnan(ds_all[m]['Yobs'].values)).sum()
-        ax2.annotate('\n$N_{obs}$: '+str(n_obs),xy=[0.65,1.05],xycoords='axes fraction',color='k')
+        if (ppt_mode):
+            pos_xy = [0.57,1.05]
+        else:
+            pos_xy = [0.65,1.05]
+        ax2.annotate('\n$N_{obs}$: '+str(n_obs),xy=pos_xy,xycoords='axes fraction',color='k')
 
         ax2.set_xlabel(legend_hist)
     
@@ -1090,6 +1118,8 @@ def plot_obs_modelled_separate(ds_all,species,site,
             ax.xaxis.set_major_locator(YearLocator())
         else:
             ax.xaxis.set_major_locator(MonthLocator())
+            if (ppt_mode):
+                ax.tick_params(axis='x', rotation=70)
                     
     if y_lim == None:    
         for i in range(len(models)):
@@ -1837,7 +1867,7 @@ def extract_region_inventory_flux(country,data_dir,species,
 
 def plot_country_flux(ds_all,species,plot_regions,
                       s_data,m_data,model_colors,
-                      start_date,end_date,
+                      start_date,end_date,ppt_mode=False,
                       plot_inventory=True,inventory_years=None,
                       data_dir=None,fix_y_axes=False,
                       add_prior_unc=False, set_global_leg=False,
@@ -1864,6 +1894,8 @@ def plot_country_flux(ds_all,species,plot_regions,
         start_date (str) and end_date (str):
             Start and end dates of the data to plot.
             Used to slice inventory data.
+        ppt_mode (logical) (optional):
+            If True, adjust global legend position to accomodate bigger fonts.
         model_colors (dict of str):
             Models and corresponding colours used to plot the model.
         plot_inventory (bool):
@@ -2164,7 +2196,7 @@ def plot_country_flux(ds_all,species,plot_regions,
         
         ncol = 2
         if set_global_leg == False:
-            leg = ax.legend(ncol=ncol,borderpad=.4,columnspacing=1.0,fontsize=10)
+            leg = ax.legend(ncol=ncol,borderpad=.4,columnspacing=1.0)
             if plot_inventory == True:
                 for l in leg.legendHandles[:-1]:
                     l.set_linewidth(3.0)
@@ -2205,7 +2237,10 @@ def plot_country_flux(ds_all,species,plot_regions,
         
         if set_global_leg:
             if n_rows > 1:
-                legend_loc = (0.5, 1.07)
+                if (ppt_mode):
+                    legend_loc = (0.5, 1.1)
+                else:
+                    legend_loc = (0.5, 1.07)
             else:
                 legend_loc = (0.5, 1.15)
             handles, labels = ax.get_legend_handles_labels()
@@ -2216,7 +2251,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                 ncol=ncol+3
             if plot_inventory == True:
                 ncol=ncol+1
-            leg = fig.legend(handles, labels, loc='upper center',ncol=ncol,borderpad=.4,columnspacing=1.0,fontsize=10,bbox_to_anchor=legend_loc)
+            leg = fig.legend(handles, labels, loc='upper center',ncol=ncol,borderpad=.4,columnspacing=1.0,bbox_to_anchor=legend_loc)
             if plot_inventory == True:
                 for l in leg.legendHandles:
                     l.set_linewidth(3.0)
@@ -2495,7 +2530,7 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
 
 #####################################################################
 
-def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,
+def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode=False,
                                  cmap=None,cmap_diff=None,c_border=None,period_override=None,
                                  plot_site_locations=False,plot_point_markers=None):
     """
@@ -2520,6 +2555,8 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,
             Dictionary of species with information for plotting (read from json file).
         m_data (dict of dict):
             Dictionary of inversion runs with filename and plot label (read from json file).
+        ppt_mode (logical) (optional):
+            If True, adjust label position to accomodate bigger fonts.
         cmap (str):
             Colour map for flux plots.
         cmap_diff (str):
@@ -2692,11 +2729,16 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,
     cbar.set_array(levels)
     cbar.set_clim(s_data[species]['fluxlim'])
 
+    if (ppt_mode):
+        labelpad_v = 20
+    else:
+        labelpad_v = 5
+
     color_bar2 = fig.colorbar(cbar,orientation='horizontal',cmap=cmap,extend='max',ax=ax[0],shrink=0.9,pad=0.01)
-    color_bar2.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)')
+    color_bar2.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)', labelpad=labelpad_v)
 
     color_bar2 = fig.colorbar(cbar,orientation='horizontal',cmap=cmap,extend='max',ax=ax[1],shrink=0.9,pad=0.01)
-    color_bar2.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)')
+    color_bar2.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)',labelpad=labelpad_v)
 
     #difference colorbar
     levels_diff = np.linspace(s_data[species]['difflim'][0],s_data[species]['difflim'][1])
@@ -2705,7 +2747,7 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,
     cbar_diff.set_clim(s_data[species]['difflim'])
 
     color_bar3 = fig.colorbar(cbar_diff,orientation='horizontal',extend='both',ax=ax[2],shrink=0.9,pad=0.01)
-    color_bar3.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)')
+    color_bar3.set_label(f'{s_data[species]["species_print"]}\n{time_out}\n(mol m$^{{-2}}$ s$^{{-1}}$)',labelpad=labelpad_v)
     
     return fig
 
@@ -3001,9 +3043,9 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                 ax_var.set_title(f'{time_out}')
                 if i == 0:
                     if '\n' in m_data[m]["label"]:
-                        ax_var.text(-0.14, 0.25, f'{m_data[m]["label"]}', size=14, transform=ax_var.transAxes, rotation=90)
+                        ax_var.text(-0.14, 0.25, f'{m_data[m]["label"]}', transform=ax_var.transAxes, rotation=90)
                     else:
-                        ax_var.text(-0.07, 0.25, f'{m_data[m]["label"]}', size=14, transform=ax_var.transAxes, rotation=90)
+                        ax_var.text(-0.07, 0.25, f'{m_data[m]["label"]}', transform=ax_var.transAxes, rotation=90)
                 
             # Add site location
             if plot_site_locations == True:

--- a/models_info.json
+++ b/models_info.json
@@ -61,7 +61,7 @@
 
     "intem_name_edgar_26sites":{
         "filename":"InTEM_NAME_EUROPE_EDGAR_26sites_intem_obs_intem_baseline",
-        "label":"InTEM NAME 31 sites (e+w)"
+        "label":"InTEM NAME 26 sites (e)"
         },
 
     "intem_13sites":{

--- a/models_info.json
+++ b/models_info.json
@@ -3,6 +3,7 @@
         "filename":"InTEM_NAME_EUROPE_EDGAR_intem_obs_intem_baseline_optimized",
         "label":"InTEM NAME EDGAR"
         },
+
     "intem_name_edgar_longrun":{
         "filename":"InTEM_NAME_EUROPE_EDGAR_longrun_intem_obs_intem_baseline_optimized",
         "label":"InTEM NAME EDGAR"
@@ -17,6 +18,7 @@
         "filename":"InTEM_NAME_EUROPE_FLAT_intem_obs_intem_baseline_optimized",
         "label":"InTEM NAME Flat"
         },
+
     "intem_name_flat_longrun":{
         "filename":"InTEM_NAME_EUROPE_FLAT_longrun_intem_obs_intem_baseline_optimized",
         "label":"InTEM NAME Flat"
@@ -26,6 +28,7 @@
             "filename":"InTEM_NAME_EUROPE_EDGARMINVAL_intem_obs_intem_baseline_optimized",
             "label":"InTEM NAME EDGAR with min value"
             },
+
     "intem_name_edgarminval_longrun":{
             "filename":"InTEM_NAME_EUROPE_EDGARMINVAL_longrun_intem_obs_intem_baseline_optimized",
             "label":"InTEM NAME EDGAR with min value"
@@ -56,6 +59,11 @@
         "label":"InTEM FLEXPART Flat all obs"
         },
 
+    "intem_name_edgar_26sites":{
+        "filename":"InTEM_NAME_EUROPE_EDGAR_26sites_intem_obs_intem_baseline",
+        "label":"InTEM NAME 31 sites (e+w)"
+        },
+
     "intem_13sites":{
         "filename":"InTEM_NAME_EUROPE_EDGAR_13sites_intem_obs_intem_baseline_optimized",
         "label":"InTEM 13 sites"
@@ -66,9 +74,9 @@
         "label":"InTEM 33 sites"
         },
 
-    "intem_XXsites_wetcharts":{
-        "filename":"InTEM_NAME_EUROPE_PARIS_selectedobs_intem_baseline_wetcharts_prior",
-        "label":"InTEM wetcharts"
+    "intem_name_wetcharts_31sites":{
+        "filename":"InTEM_NAME_EUROPE_EDGARWETCHART_31sites_intem_obs_intem_baseline",
+        "label":"InTEM NAME 31 sites (e+w)"
         },
 
 
@@ -122,14 +130,34 @@
         "label":"ELRIS InTEM obs-background-unc"
         },
 
-    "elris_35sites":{
-        "filename":"ELRIS_NAME_EUROPE_EDGAR_std_35sites",
-        "label":"ELRIS 35 sites (e)"
+    "elris_name_edgar_26sites":{
+        "filename":"ELRIS_NAME_EUROPE_EDGAR_26sites",
+        "label":"ELRIS NAME 26 sites (e)"
         },
 
-    "elris_35sites_wetcharts":{
-        "filename":"ELRIS_NAME_EUROPE_EDGARandWETLANDS_std_35sites",
-        "label":"ELRIS 35 sites(e+w)"
+    "elris_name_edgar_31sites":{
+        "filename":"ELRIS_NAME_EUROPE_EDGAR_31base",
+        "label":"ELRIS NAME 31 sites (e)"
+        },
+
+    "elris_name_wetcharts_31sites":{
+        "filename":"ELRIS_NAME_EUROPE_EDGARWETCHART_31base",
+        "label":"ELRIS NAME 31 sites (e+w)"
+        },
+
+    "elris_flex_edgar_26sites":{
+        "filename":"ELRIS_FLEXPART_EUROPE_EDGAR_26sites",
+        "label":"ELRIS FLEXPART 26 sites (e)"
+        },
+
+    "elris_flex_edgar_31sites":{
+        "filename":"ELRIS_FLEXPART_EUROPE_EDGAR_31base",
+        "label":"ELRIS FLEXPART 31 sites (e)"
+        },
+
+    "elris_flex_wetcharts_31sites":{
+        "filename":"ELRIS_FLEXPART_EUROPE_EDGARWETCHART_31base",
+        "label":"ELRIS FLEXPART 31 sites (e+w)"
         },
 
     "elris_name_edgarminval":{
@@ -193,14 +221,14 @@
         "label":"RHIME 13 sites (e)"
         },
 
-    "rhime_36sites":{
-        "filename":"RHIME_NAME_EUROPE_EDGAR_rhime_obs_baseline_optimized_36sites",
-        "label":"RHIME 36 sites (e)"
+    "rhime_name_wetcharts_31sites":{
+        "filename":"RHIME_NAME_EUROPE_EDGAR-WetCHARTs_rhime_obs_rhime_baseline_optimized_31sites",
+        "label":"RHIME NAME 31 sites (e+w)"
         }, 
 
-    "rhime_36sites_wetcharts":{
-        "filename":"RHIME_NAME_EUROPE_EDGAR-WetCHARTs_rhime_obs_rhime_baseline_optimized_36sites",
-        "label":"RHIME 36 sites (e+w)"
+    "rhime_flex_wetcharts_31sites":{
+        "filename":"RHIME_FLEXPART_EUROPE_EDGAR-WetCHARTs_std_31sites",
+        "label":"RHIME FLEXPART 31 sites (e+w)"
         },
 
     "rhime_name_edgarminval":{

--- a/species_info.json
+++ b/species_info.json
@@ -315,9 +315,9 @@
             "fluxlim":[0,5e-14],
             "difflim":[-5e-14,5e-14],
             "gwp":11100,
-            "std_run":{"intem":"name_edgar_minval",
-                       "rhime":"name_edgar_minval",
-                       "elris":"name_edgar_minval"}
+            "std_run":{"intem":"name_edgarminval",
+                       "rhime":"name_edgarminval",
+                       "elris":"name_edgarminval"}
             },   
     "cf4":{
             "species_print":"PFC-14",
@@ -337,9 +337,9 @@
             "fluxlim":[0,5e-14],
             "difflim":[-5e-14,5e-14],
             "gwp":6630,
-            "std_run":{"intem":"name_edgar_minval",
-                       "rhime":"name_edgar_minval",
-                       "elris":"name_edgar_minval"}
+            "std_run":{"intem":"name_edgarminval",
+                       "rhime":"name_edgarminval",
+                       "elris":"name_edgarminval"}
             },   
 
     "sf6":{

--- a/species_info.json
+++ b/species_info.json
@@ -111,7 +111,7 @@
         "gwp":138,
         "std_run":{"intem":"name_flat",
                    "rhime":"name_flat",
-                   "elris":"name_edgar"}
+                   "elris":"name_flat"}
         },
 
     "hfc32":{
@@ -157,7 +157,7 @@
         "gwp":3350,
         "std_run":{"intem":"name_flat",
                    "rhime":"name_flat",
-                   "elris":"name_edgar"}
+                   "elris":"name_flat"}
         }, 
 
     "hfc23":{
@@ -203,7 +203,7 @@
         "gwp":858,
         "std_run":{"intem":"name_flat",
                    "rhime":"name_flat",
-                   "elris":"name_edgar"}
+                   "elris":"name_flat"}
         },   
 
     "hfc365mfc":{
@@ -226,7 +226,7 @@
         "gwp":804,
         "std_run":{"intem":"name_flat",
                    "rhime":"name_flat",
-                   "elris":"name_edgar"}
+                   "elris":"name_flat"}
         },
 
     "hfc4310mee":{
@@ -249,7 +249,7 @@
         "gwp":1650,
         "std_run":{"intem":"name_flat",
                    "rhime":"name_flat",
-                   "elris":"name_edgar"}
+                   "elris":"name_flat"}
         },   
 
     "pfc218":{

--- a/species_info.json
+++ b/species_info.json
@@ -16,7 +16,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,5e-8],
         "difflim":[-2e-8,2e-8],
-        "gwp":28
+        "gwp":28,
+        "std_run":{"intem":"name_wetcharts_31sites",
+                   "rhime":"name_wetcharts_31sites",
+                   "elris":"name_wetcharts_31sites"}
         },
 
     "hfc134a":{
@@ -36,7 +39,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":1300
+        "gwp":1300,
+        "std_run":{"intem":"name_edgar",
+                   "rhime":"name_edgar",
+                   "elris":"name_edgar"}
         },
 
     "hfc143a":{
@@ -56,7 +62,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,5e-12],
         "difflim":[-5e-12,5e-12],
-        "gwp":4800
+        "gwp":4800,
+        "std_run":{"intem":"name_edgar",
+                   "rhime":"name_edgar",
+                   "elris":"name_edgar"}
         },
 
     "hfc125":{
@@ -76,28 +85,34 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":3170
+        "gwp":3170,
+        "std_run":{"intem":"name_edgar",
+                   "rhime":"name_edgar",
+                   "elris":"name_edgar"}
         },     
 
-        "hfc152a":{
-            "species_print":"HFC-152a",
-            "period":"yearly",
-            "units_scaling":{"intem":1e6,
-                            "rhime":1e6,
-                            "elris":1e6},
-            "model_species":{"intem":"hfc152a",
-                            "rhime":"hfc152a",
-                            "elris":"HFC_152a"},
-            "units_print":"G",
-            "dt_units":{"intem":"datetime64[Y]",
-                        "rhime":"datetime64[Y]",
-                        "elris":"datetime64[Y]"},
-            "mf_units_scaling":1e-12,
-            "mf_units_print":"ppt",
-            "fluxlim":[0,1e-11],
-            "difflim":[-1e-11,1e-11],
-            "gwp":138
-            },   
+    "hfc152a":{
+        "species_print":"HFC-152a",
+        "period":"yearly",
+        "units_scaling":{"intem":1e6,
+                        "rhime":1e6,
+                        "elris":1e6},
+        "model_species":{"intem":"hfc152a",
+                        "rhime":"hfc152a",
+                        "elris":"HFC_152a"},
+        "units_print":"G",
+        "dt_units":{"intem":"datetime64[Y]",
+                    "rhime":"datetime64[Y]",
+                    "elris":"datetime64[Y]"},
+        "mf_units_scaling":1e-12,
+        "mf_units_print":"ppt",
+        "fluxlim":[0,1e-11],
+        "difflim":[-1e-11,1e-11],
+        "gwp":138,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
+        },
 
     "hfc32":{
         "species_print":"HFC-32",
@@ -116,7 +131,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":677
+        "gwp":677,
+        "std_run":{"intem":"name_edgar",
+                   "rhime":"name_edgar",
+                   "elris":"name_edgar"}
         },    
 
     "hfc227ea":{
@@ -136,7 +154,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-12],
         "difflim":[-1e-12,1e-12],
-        "gwp":3350
+        "gwp":3350,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
         }, 
 
     "hfc23":{
@@ -156,7 +177,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-12],
         "difflim":[-1e-12,1e-12],
-        "gwp":12400
+        "gwp":12400,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
     },
 
     "hfc245fa":{
@@ -176,7 +200,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":858
+        "gwp":858,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
         },   
 
     "hfc365mfc":{
@@ -196,7 +223,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":804
+        "gwp":804,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
         },
 
     "hfc4310mee":{
@@ -216,7 +246,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-11],
         "difflim":[-1e-11,1e-11],
-        "gwp":1650
+        "gwp":1650,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_edgar"}
         },   
 
     "pfc218":{
@@ -236,7 +269,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,5e-14],
         "difflim":[-5e-14,5e-14],
-        "gwp":8900
+        "gwp":8900,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_flat"}
         },  
 
     "pfc318":{
@@ -256,7 +292,10 @@
             "mf_units_print":"ppt",
             "fluxlim":[0,5e-14],
             "difflim":[-5e-14,5e-14],
-            "gwp":9540
+            "gwp":9540,
+            "std_run":{"intem":"name_flat",
+                       "rhime":"name_flat",
+                       "elris":"name_flat"}
             },   
     "pfc116":{
             "species_print":"PFC-116",
@@ -275,7 +314,10 @@
             "mf_units_print":"ppt",
             "fluxlim":[0,5e-14],
             "difflim":[-5e-14,5e-14],
-            "gwp":11100
+            "gwp":11100,
+            "std_run":{"intem":"name_edgar_minval",
+                       "rhime":"name_edgar_minval",
+                       "elris":"name_edgar_minval"}
             },   
     "cf4":{
             "species_print":"PFC-14",
@@ -294,7 +336,10 @@
             "mf_units_print":"ppt",
             "fluxlim":[0,5e-14],
             "difflim":[-5e-14,5e-14],
-            "gwp":6630
+            "gwp":6630,
+            "std_run":{"intem":"name_edgar_minval",
+                       "rhime":"name_edgar_minval",
+                       "elris":"name_edgar_minval"}
             },   
 
     "sf6":{
@@ -314,7 +359,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,2e-13],
         "difflim":[-5e-13,5e-13],
-        "gwp":23500
+        "gwp":23500,
+        "std_run":{"intem":"name_flat",
+                   "rhime":"name_flat",
+                   "elris":"name_flat"}
         },    
 
     "n2o":{
@@ -334,7 +382,10 @@
         "mf_units_print":"ppt",
         "fluxlim":[0,1e-9],
         "difflim":[-1e-9,1e-9],
-        "gwp":265
+        "gwp":265,
+        "std_run":{"intem":"name_edgar_26sites",
+                   "rhime":"name_edgar_26sites",
+                   "elris":"name_edgar_26sites"}
         },
 
     "hfc1234yf":{


### PR DESCRIPTION
List of edits to the code:

1) Restructure reading of json files:
- Move reading of json files and definition of standard plotting colors to function initialize_settings
- Make necessary changes in function headers
- This avoids restarting the kernel after changing the files. Re-running the first cell will be enough.

2) Simplify prints when reading all f-gases:
- Add verbose logical flag in read_flux/extract_region_flux and set it to false when reading all F-gases

3) Option to use bigger font size:
- This is useful for producing plots for presentations
- flag 'ppt_mode' is defined in the first cell
- font size and annotate_coords are now defined inside function initialize_settings
- Some adjustments were made in some functions to accommodate bigger fonts
- Necessary changes were made to the functions header

4) Move standard run names to species_info.json:
- Delete option to look for alternative std file

5) Small edits:
- Add option to plot 6 regions in 2x3 subplots
- Add import sys (needed for sys.exit())
- Delete unused variable region_time_out
- Delete old fix for ELRIS
- add 'flux_total_posterior_inversion_grid' to skip_var
- do not plot separate prior nor separate posterior uncertainty when combined = True
- improve format of global legend
- Add "Save plot" cell in the notebook after all plots
- Move print statement in the notebook inside function read_flux_total_fgases

5) Bug fixes:
- Replace ds_all by ds_all.copy()
- Fix bug when plotting prior uncertainty
- Fix bug when plot_inventory == True but inventory_flux == None
- Restrict plotting of inventory between start_date and end_date to avoid partial boxes close to the y-axis
- Fix bug: variable 'c' instead of 'country'