### PR TITLE
Options to plot inversion_grid spatial fluxes in annex plots

### DIFF
--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -485,13 +485,14 @@
     "plot_site_locations = True #If True, adds markers to plots at locations of obs sites \n",
     "plot_point_markers = ['paris','london'] #plot a marker at these locations, options for 'paris', 'london', 'nw_england' (PFC-218 source) or any value [lon,lat]\n",
     "season = None #If specified plot the seasonal mean (only valable for monthly data). Options for 'DJF', 'MAM', 'JJA' and 'SON'\n",
+    "plot_inversion_grid_flux = False #If True, plots fluxes at resolution of inversion, if False, plots at the resolution of the prior\n",
     "###################################\n",
     "\n",
     "fig = func.plot_spatial_flux(ds_all_flux_scaled,species,plot_area,s_data,m_data,\n",
     "                             cmap=cmap,cmap_diff=cmap_diff,c_border=c_border,\n",
     "                             period_override=period_override,plot_site_locations=plot_site_locations,\n",
     "                             plot_point_markers=plot_point_markers,\n",
-    "                             season=season)"
+    "                             season=season,plot_inversion_grid_flux=plot_inversion_grid_flux)"
    ]
   },
   {
@@ -529,7 +530,8 @@
     "                                        cmap=cmap,cmap_diff=cmap_diff,c_border=c_border,\n",
     "                                        period_override=period_override,\n",
     "                                        plot_site_locations=plot_site_locations,\n",
-    "                                        plot_point_markers=plot_point_markers)"
+    "                                        plot_point_markers=plot_point_markers,\n",
+    "                                        plot_inversion_grid_flux=plot_inversion_grid_flux)"
    ]
   },
   {
@@ -577,13 +579,15 @@
     "var = 'flux_total_posterior'  #variable to be plotted. Options for: 'flux_total_posterior', 'flux_total_prior', 'posterior_prior_diff'\n",
     "plot_site_locations = True    #If True, adds markers to plots at locations of obs sites\n",
     "plot_point_markers = ['paris','london'] #plot a marker at these locations, options for 'paris', 'london', 'nw_england' (PFC-218 source) or any value [lon,lat]\n",
+    "plot_inversion_grid_flux = False #If True, plots fluxes at resolution of inversion, if False, plots at the resolution of the prior\n",
     "###################################\n",
     "\n",
     "fig = func.plot_spatial_flux_per_timestamp(ds_all_flux_scaled,species,plot_area,end_date,s_data,m_data,\n",
     "                                            cmap=cmap,c_border=c_border,\n",
     "                                            var=var,chop_by=chop_by,dt=dt,period_override=period_override,\n",
     "                                            plot_site_locations=plot_site_locations,\n",
-    "                                            plot_point_markers=plot_point_markers)"
+    "                                            plot_point_markers=plot_point_markers,\n",
+    "                                            plot_inversion_grid_flux=plot_inversion_grid_flux)"
    ]
   },
   {

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -499,7 +499,6 @@
     "                             period_override=period_override,plot_site_locations=plot_site_locations,\n",
     "                             plot_point_markers=plot_point_markers,\n",
     "                             season=season,set_fluxlim=set_fluxlim,plot_inversion_grid_flux=plot_inversion_grid_flux)"
-    "                             season=season,set_fluxlim=set_fluxlim)"
    ]
   },
   {
@@ -540,7 +539,7 @@
     "                                        period_override=period_override,\n",
     "                                        plot_site_locations=plot_site_locations\n",
     "                                        plot_point_markers=plot_point_markers,\n",
-    "                                        plot_inversion_grid_flux=plot_inversion_grid_flux)"
+    "                                        plot_inversion_grid_flux=plot_inversion_grid_flux,\n",
     "                                        set_fluxlim=set_fluxlim)"
    ]
   },
@@ -603,7 +602,6 @@
     "                                            plot_site_locations=plot_site_locations,\n",
     "                                            plot_point_markers=plot_point_markers,set_fluxlim = set_fluxlim\n",
     "                                            plot_inversion_grid_flux=plot_inversion_grid_flux)"
-    "                                            )"
    ]
   },
   {

--- a/PARIS_inversion_results.ipynb
+++ b/PARIS_inversion_results.ipynb
@@ -138,6 +138,7 @@
     "plot_separate = True #If True, includes all model results as separate lines (or insert a list of boolean of the same length as models to specify which models to plot)\n",
     "plot_combined = False #If True, combined results, averaged from all models (or insert a list of boolean of the same length as models to specify which models to combine)\n",
     "resample = None #If None, no resample is done. Else resample the data to the given period (options 'year' and 'season' for yearly and seasonal averages)\n",
+    "resample_uncert_correlation = False #If True, uses mean uncertainty during resampling, if False, recalculates uncertainty assuming no correlation.\n",
     "plot_resample_and_original = False #If True, plots both the resampled and original data\n",
     "period_override = None #use to override standard inversion periods, must be a list the same length as models, e.g. ['monthly','yearly']\n",
     "annex_mode = False #If True, replace the labels with more concise versions for NID Annexes.\n",
@@ -148,7 +149,7 @@
     "                             plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,\n",
     "                             add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,\n",
     "                             plot_separate=plot_separate,plot_combined=plot_combined,\n",
-    "                             resample=resample,\n",
+    "                             resample=resample,resample_uncert_correlation=resample_uncert_correlation,\n",
     "                             plot_resample_and_original=plot_resample_and_original,\n",
     "                             period_override=period_override)"
    ]
@@ -491,7 +492,7 @@
     "season = None #If specified plot the seasonal mean (only valable for monthly data). Options for 'DJF', 'MAM', 'JJA' and 'SON'\n",
     "set_fluxlim = 'auto' # Set flux colorbar limits: e.g.[0,10]|'default'|'auto'\n",
     "                        # 'default' = species_info default values and 'auto' = 99th percentile of flux_total_posterior\n",
-     "plot_inversion_grid_flux = False #If True, plots fluxes at resolution of inversion, if False, plots at the resolution of the prior\n",
+    "plot_inversion_grid_flux = False #If True, plots fluxes at resolution of inversion, if False, plots at the resolution of the prior\n",
     "###################################\n",
     "\n",
     "fig = func.plot_spatial_flux(ds_all_flux_scaled,species,plot_area,s_data,m_data,\n",
@@ -691,7 +692,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py311",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -705,7 +706,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -3037,7 +3037,6 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                                     chop_by='year',dt=1,period_override=None,
                                     plot_site_locations=False,plot_point_markers=False,set_fluxlim='default',
                                     plot_inversion_grid_flux=False):
-                                    plot_site_locations=False,plot_point_markers=False):
     """
     Plots posterior fluxes, prior fluxes or difference between these
     for all models and specific time intervals.

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -3325,7 +3325,11 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                         var_plot = np.mean(ds_all[m]['flux_total_posterior'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_prior'][indexes[m][i],:,:],axis=0)
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 elif var == 'posterior_mean_diff':
-                    var_plot = np.mean(ds_all[m]['flux_total_posterior'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_posterior'],axis=0)
+                    try:
+                        var_plot = np.mean(ds_all[m]['flux_total_posterior'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_posterior'],axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        var_plot = np.mean(ds_all[m][f'flux_total_posterior{var_append}'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m][f'flux_total_posterior{var_append}'],axis=0)
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 else:
                     try:
@@ -3352,8 +3356,13 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                     var_plot      = np.mean(slice_apost,axis=0) - np.mean(slice_apriori,axis=0)
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 elif var == 'posterior_mean_diff':
-                    mean_slice_apost = np.mean(ds_all[m]['flux_total_posterior'].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
-                    mean_apost       = np.mean(ds_all[m]['flux_total_posterior'],axis=0)
+                    try:
+                        mean_slice_apost = np.mean(ds_all[m]['flux_total_posterior'].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
+                        mean_apost       = np.mean(ds_all[m]['flux_total_posterior'],axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        mean_slice_apost = np.mean(ds_all[m][f'flux_total_posterior{var_append}'].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
+                        mean_apost       = np.mean(ds_all[m][f'flux_total_posterior{var_append}'],axis=0)
                     var_plot         = mean_slice_apost - mean_apost
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 else:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -2289,7 +2289,7 @@ def plot_country_flux(ds_all,species,plot_regions,
 def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                       cmap_diff=None,c_border=None,period_override=None,
                       plot_site_locations=False,plot_point_markers=None,
-                      season=None):
+                      season=None,plot_inversion_grid_flux=False):
     """
     Plots posterior and prior fluxes and the difference between these
     for all models.
@@ -2329,6 +2329,10 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
         season (string, default None):
             If specified, plot the seasonal mean (only valable for monthly data). 
             Options are 'DJF', 'MAM', 'JJA', 'SON'.
+        plot_inversion_grid_flux (bool, default False):
+            If True, plots fluxes at the spatial resolution of the inversion (using the 
+            inversion_grid variable). If False, plots fluxes at the spatial resolution
+            of the prior.
             
     Returns:
         fig (figure): 
@@ -2442,28 +2446,67 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                 ax2 = ax[2,i]
             
             if season is None:
-                ax0.pcolormesh(lon,lat,
-                               np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0),
-                               cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                if plot_inversion_grid_flux == True:
+                    plot_original = False
+                    try:
+                        ax0.pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0),
+                                    cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
 
-                ax1.pcolormesh(lon,lat,
-                               np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),
-                               cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                        ax1.pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_posterior_inversion_grid'][:,:,:],axis=0),
+                                    cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
 
-                flux_diff = np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0)-np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0)
+                        flux_diff = np.mean(ds_all[m]['flux_total_posterior_inversion_grid'][:,:,:],axis=0)-np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        plot_original = True
+                else:
+                    plot_original = True
+                        
+                if plot_original == True:
+                    ax0.pcolormesh(lon,lat,
+                                np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0),
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+
+                    ax1.pcolormesh(lon,lat,
+                                np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+
+                    flux_diff = np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0)-np.mean(ds_all[m]['flux_total_prior'][:,:,:],axis=0)
+                        
                 flux_diff[np.where(flux_diff) == np.nan] = 0.
                 
             else :
-                ax0.pcolormesh(lon,lat,
-                               ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values,
-                               cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                if plot_inversion_grid_flux == True:
+                    plot_original = False
+                try:
+                    ax0.pcolormesh(lon,lat,
+                                ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values,
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
 
-                ax1.pcolormesh(lon,lat,
-                               ds_all[m]['flux_total_posterior'].groupby("time.season").mean().sel(season=season).values,
-                               cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
-                
-                flux_diff = ds_all[m]['flux_total_posterior'].groupby("time.season").mean().sel(season=season).values \
-                            -ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values
+                    ax1.pcolormesh(lon,lat,
+                                ds_all[m]['flux_total_posterior_inversion_grid'].groupby("time.season").mean().sel(season=season).values,
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                    
+                    flux_diff = ds_all[m]['flux_total_posterior_inversion_grid'].groupby("time.season").mean().sel(season=season).values \
+                                -ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values
+                except:
+                    print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                    plot_original = True
+                    
+                if plot_original == True:
+                    ax0.pcolormesh(lon,lat,
+                                ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values,
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+
+                    ax1.pcolormesh(lon,lat,
+                                ds_all[m]['flux_total_posterior'].groupby("time.season").mean().sel(season=season).values,
+                                cmap=cmap,vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                    
+                    flux_diff = ds_all[m]['flux_total_posterior'].groupby("time.season").mean().sel(season=season).values \
+                                -ds_all[m]['flux_total_prior'].groupby("time.season").mean().sel(season=season).values
+                                
                 flux_diff[np.where(flux_diff) == np.nan] = 0.
                 
                 time_out = f'{season} of {time_out}'
@@ -2543,7 +2586,8 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
 
 def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode=False,
                                  cmap=None,cmap_diff=None,c_border=None,period_override=None,
-                                 plot_site_locations=False,plot_point_markers=None):
+                                 plot_site_locations=False,plot_point_markers=None,
+                                 plot_inversion_grid_flux=False):
     """
     Plots posterior fluxes and the difference between these
     for two models.
@@ -2583,6 +2627,10 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
             List of names of points to plot over larger point sources or lat/lon locations.
             See point_markers_dict for a list of options.
             e.g. ['paris','nw_england',[50.,5.]]
+        plot_inversion_grid_flux (bool, default False):
+            If True, plots fluxes at the spatial resolution of the inversion (using the 
+            inversion_grid variable). If False, plots fluxes at the spatial resolution
+            of the prior.
     Returns:
         fig (figure): 
             A plot of spatial flux posterior from two models a plot 
@@ -2676,19 +2724,45 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
                 end_print = to_datetime(end_period).strftime("%d/%m/%Y")
                 time_out = (f'{start_print} - {end_print}')
         
-            ax[0].pcolormesh(lon,lat,
-                            np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
-                            vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest',
-                            )
+            if plot_inversion_grid_flux == True:
+                plot_original = False
+                try:
+                    ax[0].pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_posterior_inversion_grid'][:,:,:],axis=0),cmap=cmap,
+                                    vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest',
+                                    )
+                except:
+                    print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                    plot_original = True
+            else:
+                plot_original = True        
+            
+            if plot_original == True:
+                ax[0].pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
+                                    vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest',
+                                    )
 
             ax[0].set_title(f'{m_data[m]["label"]}\nPosterior mean')
             
         elif i == 1:
+            if plot_inversion_grid_flux == True:
+                plot_original = False
+                try:
+                    ax[1].pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_posterior_inversion_grid'][:,:,:],axis=0),cmap=cmap,
+                                    vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
+                except:
+                    print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                    plot_original = True
+            else:
+                plot_original = True
+                    
+            if plot_original == True:
+                ax[1].pcolormesh(lon,lat,
+                                    np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
+                                    vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')  
             
-            ax[1].pcolormesh(lon,lat,
-                            np.mean(ds_all[m]['flux_total_posterior'][:,:,:],axis=0),cmap=cmap,
-                            vmin=s_data[species]['fluxlim'][0],vmax=s_data[species]['fluxlim'][1],shading='nearest')
-
             ax[1].set_title(f'{m_data[m]["label"]}\nPosterior mean')
             
         if plot_site_locations == True:
@@ -2707,8 +2781,20 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
                     ax[2].scatter(sites_info[m][s]['longitude'],sites_info[m][s]['latitude'],color='none',
                                 edgecolor='black',marker='o',s=30,zorder=2)
         
-    flux_diff = (np.mean(ds_all[all_keys[1]]['flux_total_posterior'].values[:,:,:],axis=0)-
-                 np.mean(ds_all[all_keys[0]]['flux_total_posterior'].values[:,:,:],axis=0))
+    if plot_inversion_grid_flux == True:
+        plot_original = False
+        try:
+            flux_diff = (np.mean(ds_all[all_keys[1]]['flux_total_posterior_inversion_grid'].values[:,:,:],axis=0)-
+                        np.mean(ds_all[all_keys[0]]['flux_total_posterior_inversion_grid'].values[:,:,:],axis=0))
+        except:
+            plot_original = True
+    else:
+        plot_original = True
+        
+    if plot_original == True:
+        flux_diff = (np.mean(ds_all[all_keys[1]]['flux_total_posterior'].values[:,:,:],axis=0)-
+                        np.mean(ds_all[all_keys[0]]['flux_total_posterior'].values[:,:,:],axis=0))
+        
     flux_diff[np.where(flux_diff) == np.nan] = 0.
     
     ax[2].pcolormesh(lon,lat,
@@ -2768,7 +2854,8 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                                     cmap='viridis',c_border='floralwhite',
                                     var='flux_total_posterior',
                                     chop_by='year',dt=1,period_override=None,
-                                    plot_site_locations=False,plot_point_markers=False):
+                                    plot_site_locations=False,plot_point_markers=False,
+                                    plot_inversion_grid_flux=False):
     """
     Plots posterior fluxes, prior fluxes or difference between these
     for all models and specific time intervals.
@@ -2814,6 +2901,10 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
             List of names of points to plot over larger point sources or lat/lon locations.
             See point_markers_dict for a list of options.
             e.g. ['paris','nw_england',[50.,5.]]
+        plot_inversion_grid_flux (bool, default False):
+            If True, plots fluxes at the spatial resolution of the inversion (using the 
+            inversion_grid variable). If False, plots fluxes at the spatial resolution
+            of the prior.
     Returns:
         fig (figure):
             A plot of spatial flux of the variable specified in var
@@ -2999,6 +3090,11 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                 ax_var.coastlines(resolution='50m',color=c_border,linewidth=1.)
                 ax_var.set_extent(region_limits[plot_area])
 
+    if plot_inversion_grid_flux:
+        var_append = '_inversion_grid'
+    else:
+        var_append = ''
+
     # Plot fields
     for i in range(n_cols):
         for j,m in enumerate(ds_all.keys()):
@@ -3010,12 +3106,21 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
 
             # Compute averaged quantities
             if chop_by == 'season':
+                
                 if var == 'posterior_prior_diff':
-                    var_plot = np.mean(ds_all[m]['flux_total_posterior'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_prior'][indexes[m][i],:,:],axis=0)
+                    try:
+                        var_plot = np.mean(ds_all[m][f'flux_total_posterior{var_append}'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_prior'][indexes[m][i],:,:],axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        var_plot = np.mean(ds_all[m]['flux_total_posterior'][indexes[m][i],:,:],axis=0) - np.mean(ds_all[m]['flux_total_prior'][indexes[m][i],:,:],axis=0)
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 else:
-                    var_plot = np.mean(ds_all[m][var][indexes[m][i],:,:],axis=0)
-
+                    try:
+                        var_plot = np.mean(ds_all[m][f'{var}{var_append}'][indexes[m][i],:,:],axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        var_plot = np.mean(ds_all[m][var][indexes[m][i],:,:],axis=0)
+                        
                 # Define string for caption
                 if len(dt[i]) == 1:
                     time_out = (f'{start_print[m][i]}')
@@ -3024,12 +3129,21 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
 
             else:
                 if var == 'posterior_prior_diff':
-                    slice_apost   = ds_all[m]['flux_total_posterior'].sel(time=slice(t0_date[m][i],t1_date[m][i]))
-                    slice_apriori = ds_all[m]['flux_total_prior'].sel(time=slice(t0_date[m][i],t1_date[m][i]))
+                    try:
+                        slice_apost   = ds_all[m][f'flux_total_posterior{var_append}'].sel(time=slice(t0_date[m][i],t1_date[m][i]))
+                        slice_apriori = ds_all[m][flux_total_prior].sel(time=slice(t0_date[m][i],t1_date[m][i]))
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        slice_apost   = ds_all[m]['flux_total_posterior'].sel(time=slice(t0_date[m][i],t1_date[m][i]))
+                        slice_apriori = ds_all[m]['flux_total_prior'].sel(time=slice(t0_date[m][i],t1_date[m][i]))
                     var_plot      = np.mean(slice_apost,axis=0) - np.mean(slice_apriori,axis=0)
                     var_plot[np.where(var_plot) == np.nan] = 0.
                 else:
-                    var_plot = np.mean(ds_all[m][var].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
+                    try:
+                        var_plot = np.mean(ds_all[m][f'{var}{var_append}'].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
+                    except:
+                        print(f'Cannot find inversion_grid variables for {m} so using standard flux output.')
+                        var_plot = np.mean(ds_all[m][var].sel(time=slice(t0_date[m][i],t1_date[m][i])),axis=0)
 
                 # Define string for caption
                 if dt == 1:

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -680,8 +680,8 @@ def calculate_resample_uncertainty(ds_all_original,ds_all_p,rtime,
                     n_periods = ds_all_original[m][v].resample(time=rtime).count()[:,0,:]   #number of periods in each average
                     lower = (ds_all_original[m][v.replace('percentile_','')] - ds_all_original[m][v][:,0,:])    #recalculate upper and low standard deviations
                     upper = (ds_all_original[m][v][:,1,:] - ds_all_original[m][v.replace('percentile_','')])
-                    lower_resampled = np.sqrt(((lower**2).resample(time=rtime).sum(dim="time")))/np.sqrt(n_periods)  #resample using sqrt of variances,divided by number of periods
-                    upper_resampled = np.sqrt(((upper**2).resample(time=rtime).sum(dim="time")))/np.sqrt(n_periods)
+                    lower_resampled = np.sqrt(((lower**2).resample(time=rtime).sum(dim="time")))/n_periods  #resample using sqrt of variances,divided by number of periods
+                    upper_resampled = np.sqrt(((upper**2).resample(time=rtime).sum(dim="time")))/n_periods
                     lower_out = ds_all_p[m][v.replace('percentile_','')] - lower_resampled  #recalculated percentile upper and lower bounds
                     upper_out = ds_all_p[m][v.replace('percentile_','')] + upper_resampled
                     

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -2527,15 +2527,14 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                     'GERMANY':[2,18,45,60],
                     'ITALY':[6,19,36,48],
                     'SWITZERLAND':[5.5,11,45,49],
-                    'NETHERLANDS':[3,8,50,54],
+                    'NETHERLANDS':[2.5,8,50,55],
                     'IRELAND':[-12,-4,51,56],
                     'HUNGARY':[15,24,44.5,50],
-                    'NORWAY':[3,32,55,72],
+                    'NORWAY':[1,32,55,76],
                     'BENELUX':[1,9,48,55],
                     'NWEU':[-11,11,45,62],
                     'CWEU':[-12,27,37,66],
                     'EUROPE':[-98,40,10,80]}
-    
     
     # find site info in netcdf attrs. if none present, use site info from first model with this 
     # data available
@@ -2836,10 +2835,10 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
                     'GERMANY':[2,18,45,60],
                     'ITALY':[6,19,36,48],
                     'SWITZERLAND':[5.5,11,45,49],
-                    'NETHERLANDS':[3,8,50,54],
+                    'NETHERLANDS':[2.5,8,50,55],
                     'IRELAND':[-12,-4,51,56],
                     'HUNGARY':[15,24,44.5,50],
-                    'NORWAY':[3,32,55,72],
+                    'NORWAY':[1,32,55,76],
                     'BENELUX':[1,9,48,55],
                     'NWEU':[-11,11,45,62],
                     'CWEU':[-12,27,37,66],
@@ -3128,16 +3127,16 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                       'flux_total_posterior':'Posterior mean',
                       'posterior_prior_diff':'Posterior-prior',
                       'posterior_mean_diff':'Posterior-mean'}
-
+        
     region_limits = {'UK':[-12,4,49,62],   #min_lon, max_lon, min_lat, max_lat
                     'FRANCE':[-6,9,42,52],
                     'GERMANY':[2,18,45,60],
                     'ITALY':[6,19,36,48],
                     'SWITZERLAND':[5.5,11,45,49],
-                    'NETHERLANDS':[3,8,50,54],
+                    'NETHERLANDS':[2.5,8,50,55],
                     'IRELAND':[-12,-4,51,56],
                     'HUNGARY':[15,24,44.5,50],
-                    'NORWAY':[3,32,55,72],
+                    'NORWAY':[1,32,55,76],
                     'BENELUX':[1,9,48,55],
                     'NWEU':[-11,11,45,62],
                     'CWEU':[-12,27,37,66],

--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -647,6 +647,49 @@ def read_flux_total_fgases(data_dir,species,models,s_data,m_data,regions,
     print('\nTo change the files used as the standard for each HFC/PFC, edit variable std_run in species_info.json')
 
     return ds_all
+
+#####################################################################
+def calculate_resample_uncertainty(ds_all_original,ds_all_p,rtime,
+                                   resample_uncert_correlation=False):
+    """
+    Recalculates resampled flux uncertainty, using the assumption
+    that all periods in the resampled flux average are uncorrelated.
+    Args:
+        ds_all_original (dictionary of datasets):
+            Extracted flux datasets from flux-format netcdfs.
+        ds_all_p (dictionary of datasets):
+            Same as above, but resampled down to lower time resolution, 
+            using the .mean() method.
+        rtime (str):
+            Time used for resampling, e.g. 'YS' or 'QS-DEC'.
+        resample_uncert_correlation (bool, default False):
+            If False, recalculates resampled flux uncertainties with
+            uncorrelated assumption. If True, does not recalculate
+            uncertainties, and uses the mean uncertainty.
+    Returns:
+        ds_all_p (dictionary of datasets):
+            Same dataset as above, but with updated 'percentile_...'
+            terms.
+    """
+    
+    if resample_uncert_correlation == False:
+    
+        for m in ds_all_original.keys():
+            for v in ds_all_original[m].keys():
+                if 'percentile_country' in v:
+                    n_periods = ds_all_original[m][v].resample(time=rtime).count()[:,0,:]   #number of periods in each average
+                    lower = (ds_all_original[m][v.replace('percentile_','')] - ds_all_original[m][v][:,0,:])    #recalculate upper and low standard deviations
+                    upper = (ds_all_original[m][v][:,1,:] - ds_all_original[m][v.replace('percentile_','')])
+                    lower_resampled = np.sqrt(((lower**2).resample(time=rtime).sum(dim="time")))/np.sqrt(n_periods)  #resample using sqrt of variances,divided by number of periods
+                    upper_resampled = np.sqrt(((upper**2).resample(time=rtime).sum(dim="time")))/np.sqrt(n_periods)
+                    lower_out = ds_all_p[m][v.replace('percentile_','')] - lower_resampled  #recalculated percentile upper and lower bounds
+                    upper_out = ds_all_p[m][v.replace('percentile_','')] + upper_resampled
+                    
+                    ds_all_p[m][v] = xr.DataArray(np.concatenate((np.expand_dims(lower_out,axis=1),
+                                                                    np.expand_dims(upper_out,axis=1)),axis=1),
+                                                    dims=ds_all_p[m][v].dims)
+        
+    return ds_all_p
     
 #####################################################################
 
@@ -1942,6 +1985,7 @@ def plot_country_flux(ds_all,species,plot_regions,
                       add_prior_unc=False, set_global_leg=False,
                       country_codes_as_titles=None,plot_separate=True,
                       plot_combined=False,resample=None,
+                      resample_uncert_correlation=False,
                       plot_resample_and_original=False,
                       period_override=None,
                       return_res=False):
@@ -2001,6 +2045,11 @@ def plot_country_flux(ds_all,species,plot_regions,
             Option to be passed to resample built-in function of xarray Dataset. 
             For yearly average, 'YS' option should be used; 'QS-DEC' for seasonaly average.
             See http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
+        resample_uncert_correlation (bool, default False):
+            If True, calculates the resampled uncertainty as the mean from all averaged periods.
+            If False, recalculates uncertainty assuming no correlation between all averaged periods,
+            by taking the square root of the summed variances, divided by the number of averaging 
+            periods.
         plot_resample_and_original (bool):
             If True, plots both the resampled data and the data as its original frequency.
             If False, only plots the resampled data.
@@ -2044,13 +2093,13 @@ def plot_country_flux(ds_all,species,plot_regions,
             print(f'ERROR: Option resample=\'{resample}\' is not available. Try \'year\' or \'season\'.')
             return None
 
-        tmp = {m:ds_all[m].copy() for m in ds_all.keys()}
+        ds_all_original = {m:ds_all[m].copy() for m in ds_all.keys()}
                 
         if period_override is not None: 
             for m in ds_all.keys():
                 if 'elris' in m:
-                    del tmp[m]['covariance_country_flux_total_posterior']
-            ds_all_p = {m:tmp[m].resample(time=rtime).mean(dim="time") if period_override[i] == 'monthly' else tmp[m] for i,m in enumerate(ds_all.keys())}
+                    del ds_all_original[m]['covariance_country_flux_total_posterior']
+            ds_all_p = {m:ds_all_original[m].resample(time=rtime).mean(dim="time") if period_override[i] == 'monthly' else ds_all_original[m] for i,m in enumerate(ds_all.keys())}
             for i,m in enumerate(ds_all.keys()):
                 if 'elris' in m and period_override[i] == 'monthly':
                     ds_all_p[m]['country'] = ds_all_p[m]['country'].isel(time=0).drop('time')
@@ -2061,8 +2110,8 @@ def plot_country_flux(ds_all,species,plot_regions,
         elif s_data[species]["period"]=='monthly':
             for m in ds_all.keys():
                 if 'elris' in m:
-                    del tmp[m]['covariance_country_flux_total_posterior']
-            ds_all_p = {m:tmp[m].resample(time=rtime).mean(dim="time") for m in ds_all.keys()}
+                    del ds_all_original[m]['covariance_country_flux_total_posterior']
+            ds_all_p = {m:ds_all_original[m].resample(time=rtime).mean(dim="time") for m in ds_all.keys()}
             for m in ds_all.keys():
                 if 'elris' in m:
                     ds_all_p[m]['country'] = ds_all_p[m]['country'].isel(time=0).drop('time')
@@ -2073,7 +2122,10 @@ def plot_country_flux(ds_all,species,plot_regions,
         else:
             ds_all_p = ds_all.copy()
             
-        del tmp
+        ds_all_p = calculate_resample_uncertainty(ds_all_original,ds_all_p,rtime,
+                                                  resample_uncert_correlation)
+            
+        del ds_all_original
         
         # shift timestamps of averaged data forwards to centre of inversion period
         for m in ds_all.keys():

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -8,14 +8,14 @@ import PARIS_inversion_results as func
 ### GENERAL SETTINGS
 ###########################################
 # Species to plot
-monthly_species = ['ch4']#,'n2o']
+monthly_species = []#['ch4']#,'n2o']
 
-annual_species = ['hfc125','hfc134a','hfc143a','hfc152a','hfc23',
-                  'hfc227ea','hfc245fa','hfc32','hfc365mfc','hfc4310mee',
-                  'cf4','pfc116','pfc218','pfc318','sf6'
-                    ]
+annual_species = ['hfc227ea'] #['hfc125','hfc134a','hfc143a','hfc152a','hfc23',
+                  #'hfc227ea','hfc245fa','hfc32','hfc365mfc','hfc4310mee',
+                  #'cf4','pfc116','pfc218','pfc318','sf6'
+                  #  ]
 
-combined_species = ['all_hfc','all_pfc']
+combined_species = []#['all_hfc','all_pfc']
 
 # Cities to plot
 point_markers = {'UK': ['london','edinburgh','cardiff','belfast'],
@@ -204,12 +204,14 @@ def produce_plots(regions, output_path, inventory_years):
         else:
             start_date = '2008-01-01'
 
-        if species == 'sf6':
-            period_override = ['monthly','yearly','yearly','yearly']
-        else:
-            period_override = None
-            model_period = None
-
+        #if species == 'sf6':
+            #period_override = ['monthly','yearly','yearly','yearly']
+        #    period_override = ['yearly','yearly','yearly','yearly']
+        #else:
+        #    period_override = None
+        #    model_period = None
+        period_override = None
+        model_period = None
         ### Read and scale fluxes
         for m,model in enumerate(models):
 

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -8,14 +8,14 @@ import PARIS_inversion_results as func
 ### GENERAL SETTINGS
 ###########################################
 # Species to plot
-monthly_species = []#['ch4']#,'n2o']
+monthly_species = ['ch4']#,'n2o']
 
-annual_species = ['hfc227ea'] #['hfc125','hfc134a','hfc143a','hfc152a','hfc23',
+annual_species = ['hfc125','hfc134a','hfc143a','hfc152a','hfc23',
                   #'hfc227ea','hfc245fa','hfc32','hfc365mfc','hfc4310mee',
                   #'cf4','pfc116','pfc218','pfc318','sf6'
                   #  ]
 
-combined_species = []#['all_hfc','all_pfc']
+combined_species = ['all_hfc','all_pfc']
 
 # Cities to plot
 point_markers = {'UK': ['london','edinburgh','cardiff','belfast'],
@@ -102,6 +102,7 @@ def produce_plots(regions, output_path, inventory_years):
 
         # Annual averages
         resample = 'year'
+        resample_uncert_correlation = False #recalculates uncertainties assuming no correlation
 
         # 1.1) Plot annual country fluxes from 2008 to 2023 from intem_longrun and combined from 3 std_run
         fig = func.plot_country_flux(ds_all_flux_scaled,species,regions,
@@ -109,7 +110,7 @@ def produce_plots(regions, output_path, inventory_years):
                                      plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,
                                      add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,
                                      plot_separate=plot_separate,plot_combined=plot_combined,
-                                     resample=resample,
+                                     resample=resample,resample_uncert_correlation=resample_uncert_correlation,
                                      plot_resample_and_original=plot_resample_and_original,
                                      period_override=period_override)
 
@@ -135,7 +136,7 @@ def produce_plots(regions, output_path, inventory_years):
                                               plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,
                                               add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,
                                               plot_separate=plot_separate,plot_combined=plot_combined,
-                                              resample=resample,
+                                              resample=resample,resample_uncert_correlation=resample_uncert_correlation,
                                               plot_resample_and_original=plot_resample_and_original,
                                               period_override=period_override,
                                               return_res=True)
@@ -168,14 +169,15 @@ def produce_plots(regions, output_path, inventory_years):
 
         # Monthly country fluxes
         resample = None
-
+        resample_uncert_correlation = False
+                  
         # 2) Plot monthly country fluxes from 2018 to 2023 from intem_longrun and combined from 3 std_run
         fig = func.plot_country_flux(ds_all_flux_scaled,species,regions,
                                      s_data,m_data,model_colors,start_date,end_date,ppt_mode,annex_mode,scale_co2eq,
                                      plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,
                                      add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,
                                      plot_separate=plot_separate,plot_combined=plot_combined,
-                                     resample=resample,
+                                     resample=resample,resample_uncert_correlation=resample_uncert_correlation,
                                      plot_resample_and_original=plot_resample_and_original,
                                      period_override=period_override)
 
@@ -190,7 +192,7 @@ def produce_plots(regions, output_path, inventory_years):
     ### F-gases
     end_date   = '2024-01-01'
     resample   = None
-                  
+    resample_uncert_correlation = False
 
     print('\n--- PLOTTING COUNTRY FLUXES FOR ALL F-GASES ---')
     for species in annual_species:
@@ -237,7 +239,7 @@ def produce_plots(regions, output_path, inventory_years):
                                               plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,
                                               add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,
                                               plot_separate=plot_separate,plot_combined=plot_combined,
-                                              resample=resample,
+                                              resample=resample,resample_uncert_correlation=resample_uncert_correlation,
                                               plot_resample_and_original=plot_resample_and_original,
                                               period_override=period_override,
                                               return_res=True)
@@ -270,6 +272,7 @@ def produce_plots(regions, output_path, inventory_years):
 
     ### Total HFCs/PFCs (w/o HFC-4310mee)
     resample = None
+    resample_uncert_correlation = False         
     period_override = None
     start_date = ['2008-01-01','2018-01-01','2018-01-01','2018-01-01']
     end_date   = ['2024-01-01','2024-01-01','2024-01-01','2024-01-01']
@@ -293,7 +296,7 @@ def produce_plots(regions, output_path, inventory_years):
                                               plot_inventory,inventory_years,data_dir,fix_y_axes,add_prior,
                                               add_prior_unc,set_global_leg,country_codes_as_titles=country_codes_as_titles,
                                               plot_separate=plot_separate,plot_combined=plot_combined,
-                                              resample=resample,
+                                              resample=resample,resample_uncert_correlation=resample_uncert_correlation,
                                               plot_resample_and_original=plot_resample_and_original,
                                               period_override=period_override,
                                               return_res=True)

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -11,9 +11,9 @@ import PARIS_inversion_results as func
 monthly_species = ['ch4']#,'n2o']
 
 annual_species = ['hfc125','hfc134a','hfc143a','hfc152a','hfc23',
-                  #'hfc227ea','hfc245fa','hfc32','hfc365mfc','hfc4310mee',
-                  #'cf4','pfc116','pfc218','pfc318','sf6'
-                  #  ]
+                  'hfc227ea','hfc245fa','hfc32','hfc365mfc','hfc4310mee',
+                  'cf4','pfc116','pfc218','pfc318','sf6'
+                    ]
 
 combined_species = ['all_hfc','all_pfc']
 

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -54,12 +54,13 @@ def produce_plots(regions, output_path, inventory_years):
     plot_resample_and_original = False
 
     ### Settings for spatial maps
-    models_spatial_maps = ['intem', 'elris', 'rhime']
+    models_spatial_maps = ['intem', 'elris']
     plot_area = regions[0]
     plot_site_locations = True
     plot_point_markers = point_markers[regions[0]]
     convert_flux_units = True
     set_fluxlim = 'auto'
+    plot_inversion_grid_flux = True
 
     ### Initialization
     s_data,m_data,m_colors,annotate_coords = func.initialize_settings(ppt_mode)
@@ -374,7 +375,8 @@ def produce_plots(regions, output_path, inventory_years):
                                                     chop_by=chop_by,dt=dt,period_override=period_override,
                                                     plot_site_locations=plot_site_locations,
                                                     plot_point_markers=plot_point_markers,
-                                                    set_fluxlim=set_fluxlim)
+                                                    set_fluxlim=set_fluxlim,
+                                                    plot_inversion_grid_flux=plot_inversion_grid_flux)
 
         start_year = start_date.split('-')[0]
         end_year = end_date.split('-')[0]
@@ -422,7 +424,8 @@ def produce_plots(regions, output_path, inventory_years):
                                                     chop_by=chop_by,dt=dt,period_override=period_override,
                                                     plot_site_locations=plot_site_locations,
                                                     plot_point_markers=plot_point_markers,
-                                                    set_fluxlim = set_fluxlim)
+                                                    set_fluxlim = set_fluxlim,
+                                                    plot_inversion_grid_flux=plot_inversion_grid_flux)
 
         start_year = start_date.split('-')[0]
         end_year = end_date.split('-')[0]


### PR DESCRIPTION
This pull request includes the same updates as in #48, but also includes edits to annex_plot_generator.py, so that by default spatial fluxes are created from only InTEM and ELRIS, using the inversion_grid flux variables.

UPDATE:
I've included a first draft of the recalculation of country flux uncertainties during resampling from monthly to annual (or seasonal), which is also available in #48 .