### PR TITLE
Custom limit percentile

### DIFF
--- a/PARIS_inversion_results.py
+++ b/PARIS_inversion_results.py
@@ -2508,7 +2508,8 @@ def plot_country_flux(ds_all,species,plot_regions,
 def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                       cmap_diff=None,c_border=None,period_override=None,
                       plot_site_locations=False,plot_point_markers=None,
-                      season=None,set_fluxlim='default',plot_inversion_grid_flux=False):
+                      season=None,set_fluxlim='default',set_fluxlim_percentile=None,
+                      plot_inversion_grid_flux=False):
     """
     Plots posterior and prior fluxes and the difference between these
     for all models.
@@ -2552,6 +2553,8 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
             If provided, set the colorbar limits based on the selected options.
             Options are 'default', 'auto', a list or tuple with two elements (min, max).
             The default option is 'default', which is based on species_info values.
+        set_fluxlim_percentile (float, optional):
+            If provided, set the percentile to use when setting the colorbar limits with 'auto' option.
         plot_inversion_grid_flux (bool, default False):
             If True, plots fluxes at the spatial resolution of the inversion (using the 
             inversion_grid variable). If False, plots fluxes at the spatial resolution
@@ -2618,7 +2621,7 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
                     break
                     
     # Determine flux limits based on 'flux_total_posterior'
-    fluxlim = set_flux_limits(ds_all, 'flux_total_posterior', region_limits[plot_area], s_data[species], option=set_fluxlim)
+    fluxlim = set_flux_limits(ds_all, 'flux_total_posterior', region_limits[plot_area], s_data[species], option=set_fluxlim, custom_percentile=set_fluxlim_percentile)
     difflim = tuple([-fluxlim[1],fluxlim[1]])
         
     # Find units info in netcdf attrs
@@ -2817,7 +2820,7 @@ def plot_spatial_flux(ds_all,species,plot_area,s_data,m_data,cmap=None,
 def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode=False,
                                  cmap=None,cmap_diff=None,c_border=None,period_override=None,
                                  plot_site_locations=False,plot_point_markers=None,set_fluxlim='default',
-                                 plot_inversion_grid_flux=False):
+                                 set_fluxlim_percentile=None,plot_inversion_grid_flux=False):
     """
     Plots posterior fluxes and the difference between these
     for two models.
@@ -2863,6 +2866,8 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
             If provided, set the colorbar limits based on the selected options.
             Options are 'default', 'auto', a list or tuple with two elements (min, max).
             The default option is 'default', which is based on species_info values.
+        set_fluxlim_percentile (float, optional):
+            If provided, set the percentile to use when setting the colorbar limits with 'auto' option.
     Returns:
         fig (figure): 
             A plot of spatial flux posterior from two models a plot 
@@ -2924,7 +2929,7 @@ def plot_spatial_flux_comparison(ds_all,species,plot_area,s_data,m_data,ppt_mode
                     break
                     
     # Determine flux limits based on 'flux_total_posterior'
-    fluxlim = set_flux_limits(ds_all, 'flux_total_posterior', region_limits[plot_area], s_data[species], option=set_fluxlim)
+    fluxlim = set_flux_limits(ds_all, 'flux_total_posterior', region_limits[plot_area], s_data[species], option=set_fluxlim, custom_percentil=set_fluxlim_percentile)
     difflim = tuple([-fluxlim[1],fluxlim[1]])
         
     # Find units info in netcdf attrs
@@ -3097,7 +3102,7 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
                                     var='flux_total_posterior', plot_combined=False, annex_mode=False,
                                     chop_by='year',dt=1,period_override=None,
                                     plot_site_locations=False,plot_point_markers=False,set_fluxlim='default',
-                                    plot_inversion_grid_flux=False):
+                                    set_fluxlim_percentile=None,plot_inversion_grid_flux=False):
     """
     Plots posterior fluxes, prior fluxes or difference between these
     for all models and specific time intervals.
@@ -3155,6 +3160,8 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
             If provided, set the colorbar limits based on the selected options.
             Options are 'default', 'auto', a list or tuple with two elements (min, max).
             The default option is 'default', which is based on species_info values.
+        set_fluxlim_percentile (float, optional):
+            If provided, set the percentile to use when setting the colorbar limits with 'auto' option.
     Returns:
         fig (figure):
             A plot of spatial flux of the variable specified in var
@@ -3207,7 +3214,7 @@ def plot_spatial_flux_per_timestamp(ds_all,species,plot_area,end_date,s_data,m_d
     month_names = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
     
     # Determine flux limits and define variable extend setting
-    lim = set_flux_limits(ds_all, var, region_limits[plot_area], s_data[species], option=set_fluxlim)
+    lim = set_flux_limits(ds_all, var, region_limits[plot_area], s_data[species], option=set_fluxlim, custom_percentile=set_fluxlim_percentile)
     if var in ['posterior_prior_diff','posterior_mean_diff']:
         extend ='both'
     else:
@@ -3669,7 +3676,7 @@ def convert_molar_to_mass_flux(ds, M):
 
 #####################################################################
 
-def set_flux_limits(ds_all, var, region_plot, species_info, option='default'):
+def set_flux_limits(ds_all, var, region_plot, species_info, option='default', custom_percentile=None):
     """
     Set flux limits based on the option provided:
     
@@ -3685,7 +3692,8 @@ def set_flux_limits(ds_all, var, region_plot, species_info, option='default'):
         option (None, str or list/tuple): The option for setting limits.
             - `default` for default values.
             - A list or tuple with two elements (min, max) for specified limits.
-            - 'auto' for auto-calculated values.
+            - 'auto' for auto-calculated values using the 99th percentile (if custom_percentile is None).
+        custom_percentile (float, optional): The percentile to use as the upper limit if option is 'auto'.
     
     Returns:
         tuple: A tuple containing the flux limits (min, max).
@@ -3729,7 +3737,10 @@ def set_flux_limits(ds_all, var, region_plot, species_info, option='default'):
             
         all_var = np.concatenate(all_var, axis=0)  # Concatenate along the time axis (axis=0)
         
-        upper_lim = np.quantile(all_var, 0.99)  # Calculate the 99th percentile
+        if custom_percentile is None:
+            upper_lim = np.quantile(all_var, .99) # Calculate the 99th percentile
+        else:
+            upper_lim = np.quantile(all_var, custom_percentile)
         
         if var in ['posterior_prior_diff', 'posterior_mean_diff']:
             fluxlim = (-upper_lim, upper_lim)

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -35,6 +35,42 @@ ppt_mode = False
 # Set annex_mode to True for shorter labels
 annex_mode = True
 
+# Specify the percentile to use for the color scales in the flux spatial map
+fluxlim_percentiles = {
+    'UK': {
+        'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.99, 'hfc125': 0.99, 'hfc134a': 0.99, 'hfc143a': 0.99,
+        'cf4': 0.99, 'pfc116': 0.95, 'pfc218': 0.99, 'pfc318': 0.95, 'sf6': 0.99
+    },
+    'SWITZERLAND': {
+        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
+        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+    },
+    'GERMANY': {
+        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
+        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+    },
+    'ITALY': {
+        'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.99, 'hfc125': 0.99, 'hfc134a': 0.99, 'hfc143a': 0.99,
+        'cf4': 0.99, 'pfc116': 0.99, 'pfc218': 0.95, 'pfc318': 0.99, 'sf6': 0.95
+    },
+    'NETHERLANDS': {
+        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
+        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+    },
+    'IRELAND': {
+        'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.95, 'hfc125': 0.95, 'hfc134a': 0.95, 'hfc143a': 0.95,
+        'cf4': 0.99, 'pfc116': 0.99, 'pfc218': 0.95, 'pfc318': 0.95, 'sf6': 0.95
+    },
+    'HUNGARY': {
+        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
+        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+    },
+    'NORWAY': {
+        'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.95, 'hfc125': 0.95, 'hfc134a': 0.95, 'hfc143a': 0.95,
+        'cf4': 0.95, 'pfc116': 0.95, 'pfc218': 0.95, 'pfc318': 0.95, 'sf6': 0.95
+    }
+}
+
 ###########################################
 
 def produce_plots(regions, output_path, inventory_years):
@@ -358,6 +394,8 @@ def produce_plots(regions, output_path, inventory_years):
         ds_all_flux = {}
         ds_all_flux_scaled = {}
         models_std = []
+        
+        set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
 
         if species == "hfc4310mee":
             end_date = '2023-01-01' # NOTE: no 2023 results for HFC-4310mee
@@ -392,7 +430,7 @@ def produce_plots(regions, output_path, inventory_years):
                                                     chop_by=chop_by,dt=dt,period_override=period_override,
                                                     plot_site_locations=plot_site_locations,
                                                     plot_point_markers=plot_point_markers,
-                                                    set_fluxlim=set_fluxlim,
+                                                    set_fluxlim=set_fluxlim, set_fluxlim_percentile=set_fluxlim_percentile,
                                                     plot_inversion_grid_flux=plot_inversion_grid_flux)
 
         start_year = start_date.split('-')[0]
@@ -421,6 +459,8 @@ def produce_plots(regions, output_path, inventory_years):
         ds_all_flux_scaled = {}
         models_std = []
 
+        set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
+        
         # NOTE: easy fix while there are no Rhime results for N2O
         if species == 'n2o':
             models = ['intem', 'elris']
@@ -447,7 +487,7 @@ def produce_plots(regions, output_path, inventory_years):
                                                     chop_by=chop_by,dt=dt,period_override=period_override,
                                                     plot_site_locations=plot_site_locations,
                                                     plot_point_markers=plot_point_markers,
-                                                    set_fluxlim = set_fluxlim,
+                                                    set_fluxlim = set_fluxlim, set_fluxlim_percentile=set_fluxlim_percentile,
                                                     plot_inversion_grid_flux=plot_inversion_grid_flux)
 
         start_year = start_date.split('-')[0]

--- a/annex_plot_generator.py
+++ b/annex_plot_generator.py
@@ -42,28 +42,28 @@ fluxlim_percentiles = {
         'cf4': 0.99, 'pfc116': 0.95, 'pfc218': 0.99, 'pfc318': 0.95, 'sf6': 0.99
     },
     'SWITZERLAND': {
-        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
-        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+        'ch4': 0.96, 'n2o': 0.96, 'hfc32': 0.98, 'hfc125': 0.98, 'hfc134a': 0.97, 'hfc143a': 0.97,
+        'cf4': 0.98, 'pfc116': 0.98, 'pfc218': 0.975, 'pfc318': 0.96, 'sf6': 0.99
     },
     'GERMANY': {
-        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
-        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+        'ch4': 0.98, 'n2o': 0.98, 'hfc32': 0.99, 'hfc125': 0.99, 'hfc134a': 0.99, 'hfc143a': 0.99,
+        'cf4': 0.995, 'pfc116': 0.995, 'pfc218': 0.98, 'pfc318': 0.99, 'sf6': 0.99
     },
     'ITALY': {
         'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.99, 'hfc125': 0.99, 'hfc134a': 0.99, 'hfc143a': 0.99,
         'cf4': 0.99, 'pfc116': 0.99, 'pfc218': 0.95, 'pfc318': 0.99, 'sf6': 0.95
     },
     'NETHERLANDS': {
-        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
-        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+        'ch4': 0.96, 'n2o': 0.97, 'hfc32': 0.97, 'hfc125': 0.97, 'hfc134a': 0.97, 'hfc143a': 0.96,
+        'cf4': 0.99, 'pfc116': 0.99, 'pfc218': 0.97, 'pfc318': 0.99, 'sf6': 0.99
     },
     'IRELAND': {
         'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.95, 'hfc125': 0.95, 'hfc134a': 0.95, 'hfc143a': 0.95,
         'cf4': 0.99, 'pfc116': 0.99, 'pfc218': 0.95, 'pfc318': 0.95, 'sf6': 0.95
     },
     'HUNGARY': {
-        'ch4': None, 'n2o': None, 'hfc32': None, 'hfc125': None, 'hfc134a': None, 'hfc143a': None,
-        'cf4': None, 'pfc116': None, 'pfc218': None, 'pfc318': None, 'sf6': None
+        'ch4': 0.99, 'n2o': 0.99, 'hfc32': 0.97, 'hfc125': 0.95, 'hfc134a': 0.95, 'hfc143a': 0.95,
+        'cf4': 0.99, 'pfc116': 0.995, 'pfc218': 0.96, 'pfc318': 0.965, 'sf6': 0.98
     },
     'NORWAY': {
         'ch4': 0.95, 'n2o': 0.95, 'hfc32': 0.95, 'hfc125': 0.95, 'hfc134a': 0.95, 'hfc143a': 0.95,
@@ -90,7 +90,7 @@ def produce_plots(regions, output_path, inventory_years):
     period_override = None
 
     ### Settings for spatial maps
-    models_spatial_maps = ['intem', 'elris'] # NOTE: add rhime once variable flux_total_posterior_inversion_grid becomes available
+    models_spatial_maps = ['intem','elris','rhime']
     plot_area = regions[0]
     plot_site_locations = True
     plot_point_markers = point_markers[regions[0]]
@@ -395,7 +395,10 @@ def produce_plots(regions, output_path, inventory_years):
         ds_all_flux_scaled = {}
         models_std = []
         
-        set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
+        if species in fluxlim_percentiles[plot_area].keys():
+            set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
+        else:
+            set_fluxlim_percentile = None
 
         if species == "hfc4310mee":
             end_date = '2023-01-01' # NOTE: no 2023 results for HFC-4310mee
@@ -459,7 +462,10 @@ def produce_plots(regions, output_path, inventory_years):
         ds_all_flux_scaled = {}
         models_std = []
 
-        set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
+        if species in fluxlim_percentiles[plot_area].keys():
+            set_fluxlim_percentile = fluxlim_percentiles[plot_area][species]
+        else:
+            set_fluxlim_percentile = None
         
         # NOTE: easy fix while there are no Rhime results for N2O
         if species == 'n2o':


### PR DESCRIPTION
Add the option to set which percentile to use when setting the color scaling in flux spatial maps.

This allows to customize per region and per species for the annexes.
The following countries still need to be done: SWITZERLAND, GERMANY, NETHERLANDS, HUNGARY