### PR TITLE
Fix issue #96

### DIFF
--- a/fluxy/operators/flux_align_dataset.py
+++ b/fluxy/operators/flux_align_dataset.py
@@ -83,9 +83,7 @@ def align_lat_lon(
     return aligned_ds_list
 
 
-def align_map_data(
-    ds_all: dict[xr.Dataset]
-) -> dict[xr.Dataset]:
+def align_map_data(ds_all: dict[xr.Dataset]) -> dict[xr.Dataset]:
     """
     Prepare flux datasets for flux maps by filtering variables, removing unused dimensions, and aligning time and spatial coordinates.
 

--- a/fluxy/operators/flux_combine.py
+++ b/fluxy/operators/flux_combine.py
@@ -29,9 +29,8 @@ def combine_dataset(
     )
     return {"combined": ds_output}
 
-def combine_map_dataset(
-    ds_all: dict[str, xr.Dataset]
-) -> dict[str, xr.Dataset]:
+
+def combine_map_dataset(ds_all: dict[str, xr.Dataset]) -> dict[str, xr.Dataset]:
     """
     Combine multiple xarray datasets along the 'model' dimension and return the mean dataset.
 

--- a/fluxy/operators/flux_map_resample.py
+++ b/fluxy/operators/flux_map_resample.py
@@ -167,7 +167,7 @@ def average_over_seasons(
     ds_avg = ds.groupby(groups, restore_coord_dims=True).mean(dim="time")
     ds_avg = ds_avg.rename({"season": "time"})
 
-    desired_order = ["DJF", "MAM", "JJA", "SON"] # desired season order
+    desired_order = ["DJF", "MAM", "JJA", "SON"]  # desired season order
     ordered_seasons = [s for s in desired_order if s in ds_avg.time.values]
     ds_avg = ds_avg.sel(time=ordered_seasons)
 

--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -382,22 +382,15 @@ def plot_country_flux(
     max_x = max_x.values.astype("datetime64[Y]")
     xlim = [min_x - np.timedelta64(60, "D"), max_x + np.timedelta64(60, "D")]
 
-    if max_x - min_x > np.timedelta64(20, "Y"):
-        print("test")
-        xticks = np.arange(min_x, max_x, step=np.timedelta64(5, "Y"))
+    if max_x - min_x > np.timedelta64(8, "Y"):
+        step = int(max_x - min_x) // 8 + 1
+        xticks = np.arange(min_x, max_x, step=np.timedelta64(step, "Y"))
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticks.astype("datetime64[Y]"))
-        ax.xaxis.set_minor_formatter(NullFormatter())
-
-    elif max_x - min_x > np.timedelta64(10, "Y"):
-        xticks = np.arange(min_x, max_x, step=np.timedelta64(1, "Y"))
-        ax.set_xticks(xticks)
-        ax.set_xticklabels(xticks.astype("datetime64[Y]"))
-        ax.xaxis.set_minor_formatter(NullFormatter())
+        ax.xaxis.set_major_locator(YearLocator())
 
     else:
         ax.xaxis.set_minor_locator(MonthLocator())
-        ax.xaxis.set_minor_formatter(NullFormatter())
         ax.xaxis.set_major_locator(YearLocator())
 
     ax.set_xlim(xlim)

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -304,7 +304,7 @@ def plot_sites_timeseries(
             if site_index is not None:
                 # Define label
                 label = model_labels_copy[m]
-                
+
                 # Make scatter plot
                 data = ds_all[m].isel(nsite=site_index)[var].dropna(dim="time").time
                 ax.scatter(


### PR DESCRIPTION
If plotting more than 8 years, the xticks will be displayed with a step equal to "time range divided by 8 plus 1".

Closes issue #96 