### PR TITLE
Add last year to xticks

### DIFF
--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -395,6 +395,7 @@ def plot_country_flux(
     if max_x - min_x > np.timedelta64(8, "Y"):
         step = int(max_x - min_x) // 8 + 1
         xticks = np.arange(min_x, max_x, step=np.timedelta64(step, "Y"))
+        xticks = np.append(xticks,max_x)
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticks.astype("datetime64[Y]"))
         ax.xaxis.set_major_locator(YearLocator())

--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -395,7 +395,8 @@ def plot_country_flux(
     if max_x - min_x > np.timedelta64(8, "Y"):
         step = int(max_x - min_x) // 8 + 1
         xticks = np.arange(min_x, max_x, step=np.timedelta64(step, "Y"))
-        xticks = np.append(xticks,max_x)
+        if (max_x-min_x)%np.timedelta64(step, "Y")==0:
+            xticks = np.append(xticks,max_x)
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticks.astype("datetime64[Y]"))
         ax.xaxis.set_major_locator(YearLocator())


### PR DESCRIPTION
This part of the code is only used when the timeseries has more than 8 years.
This fix adds the last year to the plot x-axis.