### PR TITLE
Fixing timeranges in timeseries plots

### DIFF
--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -347,7 +347,7 @@ def clean_timeseries_missing_data(
     )
     new_times = []
 
-    wrong_times = time[np.where(dtime > min_freq)[0] + 1]
+    wrong_times = time[np.where(dtime > min_freq)[0]]
     new_times = wrong_times + min_freq
 
     max_index = len(ds.index.values)

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -1,9 +1,11 @@
+import logging
+import os
+from datetime import timedelta
+from pathlib import Path
+
+import numpy as np
 import pandas as pd
 import xarray as xr
-import numpy as np
-import os
-from pathlib import Path
-import logging
 
 from fluxy.operators.convert import scale_variables
 
@@ -177,15 +179,12 @@ def slice_mf(
 
         # Slice data according to site
         if site is not None:
-            site_index = get_site_index(ds_all[m], site)
-
-            if site_index is None:
-                logger.warning(f"No {m} obs found for {site}.")
+            try:
+                ds_all[m] = slice_site(ds_all[m], site)
+            except ValueError as e:
+                logger.warning(f"Error slicing site {site} from {m}: {e}")
                 ds_all.pop(m)
                 continue
-
-            mask_site = ds_all[m]["number_of_identifier"] == site_index
-            ds_all[m] = ds_all[m].where(mask_site, drop=True)
 
         if len(ds_all[m]["time"]) == 0:
             # Remove model if no data left after time slicing
@@ -215,6 +214,31 @@ def slice_mf(
             ds_all[m] = ds_all[m].sel(time=both_times)
 
     return ds_all
+
+
+def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
+    """
+    Slices the dataset to only include data for a given site.
+
+    Args:
+        ds (xarray dataset):
+            Dataset with mf data of a given model.
+        site (str):
+            Site of interest.
+    Returns:
+        ds (xarray dataset):
+            Dataset with mf data of a given model, sliced to only include data for the given site.
+    """
+
+    site_index = get_site_index(ds, site)
+
+    if site_index is None:
+        raise ValueError(f"Site {site} not found in dataset.")
+
+    mask = ds["number_of_identifier"] == site_index
+    ds = ds.where(mask, drop=True)
+
+    return ds
 
 
 def get_site_index(ds: xr.Dataset, site: str) -> int | None:
@@ -258,3 +282,80 @@ def get_unique_sites(ds_all: dict[str, xr.Dataset]) -> list[str]:
     sites = np.sort(np.unique(sites))
 
     return sites
+
+
+def clean_timeseries_missing_data(
+    ds: xr.Dataset,
+    min_freq: timedelta | None = None,
+    variables_nans: list[str] = [],
+) -> xr.Dataset:
+    """Reorganise nan values in dataset based on time.
+
+    Removes or add NaN from dataset (originated from data gaps and the process of reshaping).
+    Adds back in NaN related to data gaps.
+
+    Args:
+        ds (xarray dataset):
+            Original dataset with mf data.
+        min_freq (str, optional):
+            Minimum frequency of the time series, e.g. '1H' for hourly data.
+            If provided, will add NaN values to the dataset to fill in gaps.
+            If None, a default frequency will be used based on the median time difference.
+        max_freq (str, optional):
+            Maximum frequency of the time series. Similar to min_freq, but for the upper limit.
+    Returns:
+        ds (xarray dataset):
+            Modified dataset with NaN in data gaps.
+    """
+
+    #  Ensure that the dataset is sorted by time
+    ds = ds.sortby("time")
+    # Remove all NaN from dataset
+    ds = ds.dropna(dim="index", subset=variables_nans)
+
+    # Add values to index if not already present
+    ds["index"] = ("index", np.arange(len(ds["index"])))
+
+    # Define threshold for data gap
+    time = ds.time.values
+    dtime = np.diff(time)
+    dt_median = np.median(dtime)
+
+    if min_freq is None:
+        # Calcuate a minimum frequency based on the median time difference
+        # between data points, assuming that the median is a good representation
+        # of the time difference between data points.
+        # 2x is a good value for data gaps, 1.9x is used to avoid approximation errors.
+        min_freq = 1.9 * dt_median
+    else:
+        # Comvert timedelta to numpy timedelta64 for consistency
+        min_freq = np.timedelta64(min_freq).astype(dtime.dtype)
+
+    # Check for data gaps
+    if np.all(dtime <= min_freq):
+        return ds
+
+    logger.info(
+        f"Adding NaN between data gaps using dt={dt_median.astype('timedelta64[h]')}."
+    )
+    new_times = []
+
+    wrong_times = time[np.where(dtime > min_freq)[0] + 1]
+    new_times = wrong_times + min_freq
+
+    max_index = len(ds.index.values)
+
+    new_indices = np.concatenate(
+        [
+            ds.index.values.tolist(),
+            np.arange(max_index, max_index + len(new_times), dtype=int),
+        ]
+    )
+    # Set all values to nan
+    ds = ds.reindex(index=new_indices)
+    # Assign times to the new indices
+    ds["time"] = ("index", np.concatenate([time, new_times]))
+    # Sort the dataset by time again
+    ds = ds.sortby("time")
+
+    return ds

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -322,14 +322,15 @@ def clean_timeseries_missing_data(
     # Define threshold for data gap
     time = ds.time.values
     dtime = np.diff(time)
-    dt_median = np.median(dtime)
 
     if min_freq is None:
         # Calcuate a minimum frequency based on the median time difference
         # between data points, assuming that the median is a good representation
         # of the time difference between data points.
         # 2x is a good value for data gaps, 1.9x is used to avoid approximation errors.
+        dt_median = np.median(dtime)
         min_freq = 1.9 * dt_median
+        logger.info(f"Using median time difference 1.9 * {dt_median=} as min_freq.")
     elif isinstance(min_freq, str):
         # From pandas freq string
         min_freq = pd.to_timedelta(min_freq).to_numpy().astype(dtime.dtype)
@@ -342,7 +343,7 @@ def clean_timeseries_missing_data(
         return ds
 
     logger.info(
-        f"Adding NaN between data gaps using dt={dt_median.astype('timedelta64[h]')}."
+        f"Adding NaN between data gaps using dt={min_freq.astype('timedelta64[h]')} hours."
     )
     new_times = []
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -301,11 +301,11 @@ def clean_timeseries_missing_data(
         ds (xarray dataset):
             Original dataset with mf data.
         min_freq (str, optional):
-            Minimum frequency of the time series, e.g. '1H' for hourly data.
+            Minimum frequency of the time series, e.g. '1h' for hourly data.
             If provided, will add NaN values to the dataset to fill in gaps.
             If None, a default frequency will be used based on the median time difference.
-        max_freq (str, optional):
-            Maximum frequency of the time series. Similar to min_freq, but for the upper limit.
+            This can be given either as a string compatible with pandas frequency strings
+            or as a timedelta object.
     Returns:
         ds (xarray dataset):
             Modified dataset with NaN in data gaps.

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -340,7 +340,7 @@ def clean_timeseries_missing_data(
         return ds
 
     logger.info(
-        f"Adding NaN between data gaps using dt={min_freq.astype('timedelta64[h]')} hours."
+        f"Adding NaN between data gaps using dt={min_freq.astype('timedelta64[h]')}."
     )
     new_times = []
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -327,10 +327,9 @@ def clean_timeseries_missing_data(
         # Calcuate a minimum frequency based on the median time difference
         # between data points, assuming that the median is a good representation
         # of the time difference between data points.
-        # 2x is a good value for data gaps, 1.9x is used to avoid approximation errors.
         dt_median = np.median(dtime)
-        min_freq = 1.9 * dt_median
-        logger.info(f"Using median time difference 1.9 * {dt_median=} as min_freq.")
+        min_freq = dt_median
+        logger.info(f"Using median time difference {dt_median=} as min_freq.")
     elif isinstance(min_freq, str):
         # From pandas freq string
         min_freq = pd.to_timedelta(min_freq).to_numpy().astype(dtime.dtype)

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -327,8 +327,7 @@ def clean_timeseries_missing_data(
         # Calcuate a minimum frequency based on the median time difference
         # between data points, assuming that the median is a good representation
         # of the time difference between data points.
-        dt_median = np.median(dtime)
-        min_freq = dt_median
+        min_freq = np.median(dtime)
     elif isinstance(min_freq, str):
         # From pandas freq string
         min_freq = pd.to_timedelta(min_freq).to_numpy().astype(dtime.dtype)

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -12,6 +12,9 @@ from fluxy.operators.convert import scale_variables
 logger = logging.getLogger(__name__)
 
 
+FrequencyType = timedelta | str | None
+
+
 def slice_flux(
     ds_all: dict[str, xr.Dataset],
     config_data: dict[str, str | float] = {},
@@ -286,7 +289,7 @@ def get_unique_sites(ds_all: dict[str, xr.Dataset]) -> list[str]:
 
 def clean_timeseries_missing_data(
     ds: xr.Dataset,
-    min_freq: timedelta | None = None,
+    min_freq: FrequencyType = None,
     variables_nans: list[str] = [],
 ) -> xr.Dataset:
     """Reorganise nan values in dataset based on time.
@@ -327,6 +330,9 @@ def clean_timeseries_missing_data(
         # of the time difference between data points.
         # 2x is a good value for data gaps, 1.9x is used to avoid approximation errors.
         min_freq = 1.9 * dt_median
+    elif isinstance(min_freq, str):
+        # From pandas freq string
+        min_freq = pd.to_timedelta(min_freq).to_numpy().astype(dtime.dtype)
     else:
         # Comvert timedelta to numpy timedelta64 for consistency
         min_freq = np.timedelta64(min_freq).astype(dtime.dtype)

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -329,7 +329,6 @@ def clean_timeseries_missing_data(
         # of the time difference between data points.
         dt_median = np.median(dtime)
         min_freq = dt_median
-        logger.info(f"Using median time difference {dt_median=} as min_freq.")
     elif isinstance(min_freq, str):
         # From pandas freq string
         min_freq = pd.to_timedelta(min_freq).to_numpy().astype(dtime.dtype)

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -129,8 +129,13 @@ def plot_mf_timeseries(
             model_color = model_colors[mdiff0]
 
         ds_plot = ds_all[m]
-        # Select only the site to plot
-        ds_plot = slice_site(ds_plot, site)
+        # Check there is only one site in the dataset 
+        if len(np.unique(ds_plot['number_of_identifier'])) > 1:
+            raise ValueError(
+                f"Dataset {m} contains more than one site. "
+                "Use slice_site to select a single site."
+            )
+        
         # Clean the time dimension
         ds_plot = clean_timeseries_missing_data(
             ds_plot, variables_nans=vars_to_plot, min_freq=time_freq_min

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -170,6 +170,8 @@ def plot_mf_timeseries(
                     color=plot_color,
                     alpha=0.8,
                     linewidth=2.0,
+                    marker="o",
+                    markersize=1.5,
                     label=f"{model_label} {config.mf_labels[var]}",
                 )
 

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -1,13 +1,21 @@
+import logging
+from datetime import timedelta
+from typing import Literal
+
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from matplotlib.dates import MonthLocator, YearLocator
 from matplotlib.ticker import NullFormatter
-import matplotlib.pyplot as plt
-from typing import Literal
+
 from fluxy import config
+from fluxy.operators.select import (
+    clean_timeseries_missing_data,
+    get_site_index,
+    get_unique_sites,
+    slice_site,
+)
 from fluxy.plots.utils import set_min_decimal_points
-from fluxy.operators.select import get_unique_sites, get_site_index
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +36,7 @@ def plot_mf_timeseries(
     },
     diff_include: list[str] | None = None,
     y_lim: None | list[float] = None,
+    time_freq_min: timedelta | None = None,
 ):
     """
     Timeseries plots of observations, modelled mole fractions, baseline mf and/or
@@ -114,14 +123,22 @@ def plot_mf_timeseries(
             model_label = f"{model_labels[mdiff0]} - {model_labels[mdiff1]}"
             model_color = model_colors[mdiff0]
 
+        ds_plot = ds_all[m]
+        # Select only the site to plot
+        ds_plot = slice_site(ds_plot, site)
+        # Clean the time dimension
+        ds_plot = clean_timeseries_missing_data(
+            ds_plot, variables_nans=vars_to_plot, min_freq=time_freq_min
+        )
+
         # Loop over all variables to plot
         for var in vars_to_plot:
 
-            if var not in ds_all[m].keys():
+            if var not in ds_plot.keys():
                 raise KeyError(f"Variable {var} not found in {m}.")
 
             # Get var unit
-            plot_units.append(ds_all[m][var].attrs["units"])
+            plot_units.append(ds_plot[var].attrs["units"])
 
             # Define plotting color
             plot_color = model_color[config.mf_color_index[var]]
@@ -131,8 +148,8 @@ def plot_mf_timeseries(
             if var == "mf_observed" or plot_type == "diff":
                 # Make scatter plot
                 ax[iax, 0].scatter(
-                    ds_all[m]['time'].values,
-                    ds_all[m][var].values,
+                    ds_plot["time"].values,
+                    ds_plot[var].values,
                     color=plot_color,
                     label=f"{model_label} {config.mf_labels[var]}",
                     s=8,
@@ -143,8 +160,8 @@ def plot_mf_timeseries(
             else:
                 # Make line plot
                 ax[iax, 0].plot(
-                    ds_all[m]['time'].values,
-                    ds_all[m][var].values,
+                    ds_plot["time"].values,
+                    ds_plot[var].values,
                     color=plot_color,
                     alpha=0.8,
                     linewidth=2.0,
@@ -159,15 +176,15 @@ def plot_mf_timeseries(
                         f"Option plot_type='diff' does not accept uncertainties. Replace '{unc_var}' by None."
                     )
 
-                if unc_var not in ds_all[m].keys():
+                if unc_var not in ds_plot.keys():
                     raise KeyError(f"Variable {unc_var} not found in {m}.")
 
                 if unc_var.split("_")[0] == "percentile":
                     # Add uncertainty band
                     ax[iax, 0].fill_between(
-                        ds_all[m].time.values,
-                        ds_all[m][unc_var][0, :].values,
-                        ds_all[m][unc_var][1, :].values,
+                        ds_plot.time.values,
+                        ds_plot[unc_var][0, :].values,
+                        ds_plot[unc_var][1, :].values,
                         color=plot_color,
                         alpha=0.2,
                     )
@@ -175,9 +192,9 @@ def plot_mf_timeseries(
                 else:
                     # Add error bar
                     ax[iax, 0].errorbar(
-                        ds_all[m].time.values,
-                        ds_all[m][var].values,
-                        ds_all[m][unc_var].values,
+                        ds_plot.time.values,
+                        ds_plot[var].values,
+                        ds_plot[unc_var].values,
                         color=plot_color,
                         alpha=0.4,
                         fmt="none",
@@ -186,7 +203,7 @@ def plot_mf_timeseries(
         # Plot histogram
         plot_histogram(
             ax[iax, 1],
-            ds_all[m],
+            ds_plot,
             m,
             vars_to_plot,
             diff_include,
@@ -227,17 +244,14 @@ def plot_mf_timeseries(
             for l in leg.legendHandles:
                 l.set_linewidth(5.0)
 
-        if len(ds_all[m]['time']) <= 1:
+        if len(ds_plot["time"]) <= 1:
             continue
-        start_date = ds_all[m]['time'].values.min()
-        end_date = ds_all[m]['time'].values.max()
-        
+        start_date = ds_plot["time"].values.min()
+        end_date = ds_plot["time"].values.max()
+
         # Set timeseries x-axis ticks
         if (
-            int(
-                end_date.astype("datetime64[M]")
-                - start_date.astype("datetime64[M]")
-            )
+            int(end_date.astype("datetime64[M]") - start_date.astype("datetime64[M]"))
             > 12
         ):
             ax[iax, 0].xaxis.set_minor_locator(MonthLocator())

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -69,6 +69,11 @@ def plot_mf_timeseries(
             If None, plots the histogram of the variables specified in include.
         y_lim (list of float, optional):
             Mix/max y axis limits to apply to all plots.
+        time_freq_min (FrequencyType, optional):
+            Time frequency minimum of the timeserie that should be shown as continous 
+            line. If the frequency is lower than this, the line will be discontinous.
+            see :py:func:`fluxy.operators.select.clean_timeseries_missing_data`
+            for more information.
     Returns:
         fig (figure):
             A timeseries and histogram plot for each model included.

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 from typing import Literal
 
 import matplotlib.pyplot as plt
@@ -10,6 +9,7 @@ from matplotlib.ticker import NullFormatter
 
 from fluxy import config
 from fluxy.operators.select import (
+    FrequencyType,
     clean_timeseries_missing_data,
     get_site_index,
     get_unique_sites,
@@ -36,7 +36,7 @@ def plot_mf_timeseries(
     },
     diff_include: list[str] | None = None,
     y_lim: None | list[float] = None,
-    time_freq_min: timedelta | None = None,
+    time_freq_min: FrequencyType = None,
 ):
     """
     Timeseries plots of observations, modelled mole fractions, baseline mf and/or

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,12 @@
+from datetime import timedelta
 import itertools
 
 import pytest
 
+import xarray as xr
+import pandas as pd
 from fluxy.operators.mf import compute_mf_difference, stats_mf
-from fluxy.operators.select import slice_flux, slice_mf
+from fluxy.operators.select import slice_flux, slice_mf, clean_timeseries_missing_data
 from fluxy.test_utils.models import get_loaded_models, test_models
 
 ds_all_mf = get_loaded_models("concentration")
@@ -56,3 +59,44 @@ def test_stats_mf(stat):
         ds_all_mf,
         stats_type=stat,
     )
+
+
+ds_test = xr.Dataset(
+    {
+        "var1": (["index"], [1, 2, None, 4, 5]),
+        "var2": (["index"], [None, 2, None, None, 5]),
+    },
+    coords={
+        "time": ("index", pd.date_range("2020-01-01", periods=5, freq="D")),
+    },
+)
+
+
+def test_clean_timeseries_missing_data():
+
+    ds_out = clean_timeseries_missing_data(ds_test)
+    # Missing days should have been replaced
+    assert len(ds_out.time) == 5
+
+
+def test_clean_timeseries_missing_data_with_freq_pd():
+
+    ds_out = clean_timeseries_missing_data(ds_test, min_freq="1D")
+    # Missing days should have been replaced
+    assert len(ds_out.time) == 5
+
+
+def test_clean_timeseries_missing_data_with_freq_timedelta():
+
+    ds_out = clean_timeseries_missing_data(ds_test, min_freq=timedelta(days=1))
+    # Missing days should have been replaced
+    assert len(ds_out.time) == 5
+
+
+def test_clean_timeseries_missing_data_removed():
+
+    ds_out = clean_timeseries_missing_data(
+        ds_test, min_freq="10D", variables_nans=["var2"]
+    )
+    # Missing days should have been removed
+    assert len(ds_out.time) == 2


### PR DESCRIPTION
In the timeseries plot, we sometimes have gaps in the measurements. 

This PR attempts to fix which gaps are shown and which are not.

With the old format this was easy, becauase we could resample the time axis to the freqency we want.
However in the new format this is more tricky.

We can do this behaviour by adding nan values between gaps. so that they don't show on the plot