### PR TITLE
Delete NaN variables from mf dataset

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -789,7 +789,7 @@ def edit_vars_and_attributes(
             # Delete NaN data variables
             for var in ds.data_vars:
                 if ds[var].isnull().all():
-                    logger.warning(f"Removing {var} from {model}: all data in NaN")
+                    logger.warning(f"Removing {var} from {model}: all data is NaN")
                     ds = ds.drop_vars(var)
 
     return ds

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -786,4 +786,10 @@ def edit_vars_and_attributes(
                 coords=ds["platform"].coords,
             )
 
+            # Delete NaN data variables
+            for var in ds.data_vars:
+                if ds[var].isnull().all():
+                    logger.warning(f"Removing {var} from {model}: all data in NaN")
+                    ds = ds.drop_vars(var)
+
     return ds


### PR DESCRIPTION
In the CIF-EnKS dataset some variables were all NaN: `intake_height` and `stdev_mf_model`. This was leading to problems when using `.dropna('index)` in` stats_mf`. For now, this check is done only for CIF-EnKS, but this can be made general if it becomes a problem for other datasets.