### PR TITLE
Adding site height to platform names when this data is missing and updating plotting to use this new info

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -15,7 +15,7 @@ from typing import Literal
 
 from fluxy import config
 from fluxy.operators.regions import extract_region_flux
-from fluxy.operators.select import slice_flux
+from fluxy.operators.select import slice_flux,get_inlet_height
 from fluxy.operators.flux_align_dataset import align_time
 
 logger = logging.getLogger(__name__)
@@ -242,7 +242,8 @@ def read_model_output(
 
         # Fix variables and attributes
         ds_all[m] = edit_vars_and_attributes(
-            ds_all[m], m, period[i], file_type, config_data.get("regions_info", {})
+            ds_all[m], m, period[i], file_type, config_data.get("regions_info", {}),
+            config_data.get("site_info",{})
         )
 
     return ds_all
@@ -532,6 +533,7 @@ def edit_vars_and_attributes(
     frequency: str,
     file_type: Literal["flux", "concentration"],
     regions_info: dict[str, str],
+    site_info: dict[str,dict],
 ) -> xr.Dataset:
     """
     Edit dataset variables and attributes.
@@ -550,6 +552,8 @@ def edit_vars_and_attributes(
             Options for "flux" and "concentration".
         regions_info (dict of str):
             Dictionary with country and region names (read from json file).
+        site_info (dict of str):
+            Dictionary with site info (read from json file).
 
     Returns:
         ds (xarray dataset):
@@ -744,6 +748,9 @@ def edit_vars_and_attributes(
             ds = ds.assign(
                 assimilation_flag=("index", np.ones(ds["index"].size, dtype=int))
             )
+            
+        #if "time" not in ds["assimilation_flag"].coords:
+        #    ds['assimilation_flag'] = ds["assimilation_flag"].assign_coords(time=ds["time"].values)
 
         # Test that the number of identifiers had valid values
         max_num_id, min_num_id = (
@@ -767,6 +774,22 @@ def edit_vars_and_attributes(
         ds = ds.assign_coords(
             {var: ds[var] for var in ["number_of_identifier", "time", "platform"]}
         )
+        
+        # Add in inlet heights to list of platforms, if this is missing from site names
+        if any([True if '-' not in i else False for i in ds['platform'].values]):
+            updated_sites = []
+            for i,site in enumerate(ds['platform'].values):
+                site_letters = site.split('-')[0]
+                if '-' not in site:
+                    site_height = get_inlet_height(site=site_letters,site_info=site_info)
+                    logger.warning((f"No platform height included in {model} "+
+                                    f"for {site_letters} ."+
+                                    f"So assuming height of {site_height}."))
+                    updated_sites.append(f"{site}-{site_height}")
+                else:
+                    updated_sites.append(site)    
+                
+            ds = ds.assign_coords({'platform':updated_sites})
 
         # Fix for InTEM (units of platform are wrongly set to mol mol-1)
         ds["platform"].attrs.pop("units", None)

--- a/fluxy/operators/mf.py
+++ b/fluxy/operators/mf.py
@@ -147,7 +147,7 @@ def stats_mf(
 
     # names of sites
     sites_all = get_unique_sites(ds_all)
-
+    
     # init empty list to hold results for individual sites
     stats = []
 

--- a/fluxy/operators/mf.py
+++ b/fluxy/operators/mf.py
@@ -156,7 +156,7 @@ def stats_mf(
         for model, ds in ds_all.items():
             # Remove the NaNs
             ds = ds.dropna("index")
-            site_index = get_site_index(ds, site)
+            site_index = get_site_index(ds, site,full_site_name=True)
             if site_index is None:
                 continue
             mask_site = ds["number_of_identifier"] == site_index

--- a/fluxy/operators/mf.py
+++ b/fluxy/operators/mf.py
@@ -147,7 +147,7 @@ def stats_mf(
 
     # names of sites
     sites_all = get_unique_sites(ds_all)
-    
+
     # init empty list to hold results for individual sites
     stats = []
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -181,6 +181,7 @@ def slice_mf(
 
         # Slice data according to time window
         mask = (ds_all[m]["time"] >= start_date) & (ds_all[m]["time"] <= end_date)
+        
         if not keep_unassimilated:
             # Mask assimilated data only
             mask &= ds_all[m]["assimilation_flag"] == 1
@@ -188,12 +189,12 @@ def slice_mf(
 
         # Slice data according to site
         if site is not None:
-            try:
-                ds_all[m] = slice_site(ds_all[m], site)
-            except ValueError as e:
-                logger.warning(f"Error slicing site {site} from {m}: {e}")
-                ds_all.pop(m)
-                continue
+            #try:
+            ds_all[m] = slice_site(ds_all[m], site,combine_sites=True)
+            #except ValueError as e:
+            #    logger.warning(f"Error slicing site {site} from {m}: {e}")
+            #    ds_all.pop(m)
+            #    continue
 
         if len(ds_all[m]["time"]) == 0:
             # Remove model if no data left after time slicing
@@ -225,7 +226,10 @@ def slice_mf(
     return ds_all
 
 
-def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
+def slice_site(ds: xr.Dataset, 
+               site: str, 
+               combine_sites: bool = False
+) -> xr.Dataset:
     """
     Slices the dataset to only include data for a given site.
 
@@ -244,8 +248,17 @@ def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
     if site_index is None:
         raise ValueError(f"Site {site} not found in dataset.")
 
-    mask = ds["number_of_identifier"] == site_index
+    for i,site_id in enumerate(site_index):
+        if i == 0:
+            mask = ds["number_of_identifier"] == site_id
+        else:
+            mask += ds["number_of_identifier"] == site_id
+                    
     ds = ds.where(mask, drop=True)
+    
+    if combine_sites == True:
+        
+        ds['number_of_identifier'].values[:] = ds['number_of_identifier'].values[0] 
 
     return ds
 
@@ -265,12 +278,49 @@ def get_site_index(ds: xr.Dataset, site: str) -> int | None:
             Returns None if site does not exist.
     """
 
-    if site in ds["platform"]:
-        index = np.where(ds["platform"] == site)[0][0]
+    #if site in ds["platform"]:
+        #index = np.where(ds["platform"] == site)[0][0]
+    index = [i for i,s in enumerate(ds['platform'].values) if site in s]
+    
+    if index == []:
+        
+        return None
+    
+    else:
+        
         return index
 
-    return None
+def get_inlet_height(site:str,site_info: dict[str:dict]) -> int | None:
+    """
+    Extract the inlet height from site_info.json.
+    This function is used to update the 'platform' variable when 
+    site height is missing, and only extracts the greatest height 
+    from all available at the specified site.
+    
+    Args:
+        site (str):
+            3-letter site code.
+        site_info (dict of dict):
+            Data extracted from site_info.json.
+    Returns:
+        max_height (int):
+            Maximum height from all networks and inlets available ast s
+    """
+    
+    all_heights = []
 
+    for network in site_info[site].keys():
+        if 'height' in site_info[site][network].keys():
+            all_heights += site_info[site][network]['height']
+
+    if all_heights == []:
+        logger.warning(f"No height info available for {site} in site_info.json so using 0m.")
+        max_height = 0
+            
+    else:
+        max_height = np.max([int(h.strip('m')) for h in all_heights])
+        
+    return max_height
 
 def get_unique_sites(ds_all: dict[str, xr.Dataset]) -> list[str]:
     """
@@ -288,7 +338,10 @@ def get_unique_sites(ds_all: dict[str, xr.Dataset]) -> list[str]:
     for ds in ds_all.values():
         sites = np.concatenate([sites, ds["platform"].values])
 
+    #natsort package not included as default so need to find alternative
+    #sites = np.array(natsorted(np.unique(sites)))
     sites = np.sort(np.unique(sites))
+    
 
     return sites
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -189,12 +189,12 @@ def slice_mf(
 
         # Slice data according to site
         if site is not None:
-            #try:
-            ds_all[m] = slice_site(ds_all[m], site,combine_sites=True)
-            #except ValueError as e:
-            #    logger.warning(f"Error slicing site {site} from {m}: {e}")
-            #    ds_all.pop(m)
-            #    continue
+            try:
+                ds_all[m] = slice_site(ds_all[m], site,combine_sites=True)
+            except ValueError as e:
+                logger.warning(f"Error slicing site {site} from {m}: {e}")
+                ds_all.pop(m)
+                continue
 
         if len(ds_all[m]["time"]) == 0:
             # Remove model if no data left after time slicing

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -243,7 +243,7 @@ def slice_site(ds: xr.Dataset,
             Dataset with mf data of a given model, sliced to only include data for the given site.
     """
 
-    site_index = get_site_index(ds, site)
+    site_index = get_site_index(ds, site, full_site_name=False)
 
     if site_index is None:
         raise ValueError(f"Site {site} not found in dataset.")
@@ -263,7 +263,7 @@ def slice_site(ds: xr.Dataset,
     return ds
 
 
-def get_site_index(ds: xr.Dataset, site: str) -> int | None:
+def get_site_index(ds: xr.Dataset, site: str, full_site_name: False) -> int | None:
     """
     Gets the index of a given site in a dataset.
 
@@ -272,6 +272,9 @@ def get_site_index(ds: xr.Dataset, site: str) -> int | None:
             Dataset with mf data of a given model.
         site (str):
             Site of interest.
+        full_site_name (bool):
+            If True, matches full platform name, e.g 'MHD-10', 
+            else only matches 3-letter code, e.g. 'MHD'.
     Returns:
         index (int):
             Index of site of interest in the dataset.
@@ -280,7 +283,11 @@ def get_site_index(ds: xr.Dataset, site: str) -> int | None:
 
     #if site in ds["platform"]:
         #index = np.where(ds["platform"] == site)[0][0]
-    index = [i for i,s in enumerate(ds['platform'].values) if s == site]
+    if full_site_name == False:
+        index = [i for i,s in enumerate(ds['platform'].values) if site in s]
+    else:
+        index = [i for i,s in enumerate(ds['platform'].values) if s == site]
+        
     
     if index == []:
         

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -280,7 +280,7 @@ def get_site_index(ds: xr.Dataset, site: str) -> int | None:
 
     #if site in ds["platform"]:
         #index = np.where(ds["platform"] == site)[0][0]
-    index = [i for i,s in enumerate(ds['platform'].values) if site in s]
+    index = [i for i,s in enumerate(ds['platform'].values) if s == site]
     
     if index == []:
         

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -354,7 +354,7 @@ def plot_sites_timeseries(
 
         for i, m in enumerate(models):
 
-            site_index = get_site_index(ds_all[m], site)
+            site_index = get_site_index(ds_all[m], site,full_site_name=True)
 
             if site_index is None:
                 continue

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -380,7 +380,7 @@ def plot_sites_timeseries(
     )
 
     ax.set_xticks(np.arange(siteList.size))
-    ax.set_xticklabels(siteList)
+    ax.set_xticklabels([f"{s.split('-')[0]}\n{s.split('-')[1]}m" for s in siteList])
 
     if (
         int(dt_end_date.astype("datetime64[M]") - dt_start_date.astype("datetime64[M]"))

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -129,6 +129,7 @@ def plot_mf_timeseries(
             model_color = model_colors[mdiff0]
 
         ds_plot = ds_all[m]
+    
         # Check there is only one site in the dataset
         if len(np.unique(ds_plot["number_of_identifier"])) > 1:
             raise ValueError(
@@ -316,7 +317,7 @@ def plot_sites_timeseries(
     dt_end_date = np.datetime64(end_date)
     siteList = get_unique_sites(ds_all)
     model_labels_copy = model_labels.copy()
-
+    
     # Create figure
     fig, ax = plt.subplots(1, 1, figsize=(0.7 * len(siteList), 8))
 

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -129,7 +129,7 @@ def plot_mf_timeseries(
             model_color = model_colors[mdiff0]
 
         ds_plot = ds_all[m]
-    
+
         # Check there is only one site in the dataset
         if len(np.unique(ds_plot["number_of_identifier"])) > 1:
             raise ValueError(
@@ -182,7 +182,7 @@ def plot_mf_timeseries(
                 )
 
             unc_var = include[var]
-
+            
             if unc_var:
                 if plot_type == "diff":
                     raise ValueError(
@@ -190,7 +190,19 @@ def plot_mf_timeseries(
                     )
 
                 if unc_var not in ds_plot.keys():
-                    raise KeyError(f"Variable {unc_var} not found in {m}.")
+                    if 'percentile' in unc_var:
+                        unc_var_in = unc_var
+                        unc_var = unc_var.replace('percentile','stdev')
+                        
+                    elif 'stdev' in unc_var:
+                        unc_var_in = unc_var
+                        unc_var = unc_var.replace('stdev','percentile')
+
+                    if unc_var not in ds_plot.keys():
+                        KeyError(f"Variables {unc_var_in} and {unc_var} not found in {m}.")
+                    else:
+                        print(logger.warning(f"Variable {unc_var_in} not found in {m} so reading uncert from {unc_var}."))
+                #raise KeyError(f"Variable {unc_var} not found in {m}.")
 
                 if unc_var.split("_")[0] == "percentile":
                     # Add uncertainty band
@@ -317,14 +329,17 @@ def plot_sites_timeseries(
     dt_end_date = np.datetime64(end_date)
     siteList = get_unique_sites(ds_all)
     model_labels_copy = model_labels.copy()
-    
+
     # Create figure
     fig, ax = plt.subplots(1, 1, figsize=(0.7 * len(siteList), 8))
 
     assert margin < 0.5, "Margin must be smaller than 0.5"
     assert margin > 0, "Margin must be positive"
 
-    model_offset = (1 - 2 * margin) / (len(models) - 1)
+    if len(models) > 1:
+        model_offset = (1 - 2 * margin) / (len(models) - 1)
+    else:
+        model_offset = 1
 
     for site_iter, site in enumerate(siteList):
         if site_iter != 0:
@@ -437,7 +452,7 @@ def plot_histogram(
     # Loop over all variables to plot in histogram
     for v, var in enumerate(hist_to_plot):
 
-        if var not in ds.keys():
+        if var not in ds.keys():                   
             raise KeyError(f"Variable {var} not found in {model}.")
 
         if diff_include:


### PR DESCRIPTION
Not sure if this is being worked on by anyone, but I found some minor issues when testing InTEM's new-format concentrations files.

The new concentrations file format states that the 'platform' coordinate should indentify sites by their 3-letter code and an inlet height, so I've updated a few functions to allow for this:

- Added `get_inlet_height` which reads inlet height info from sites_info.json. I've set this so that it reads in the heightest height available for each site, (which I think is the default for most sites more recently). This info can be used if inlet height isn't included in the platform names.
- Updated `edit_vars_and_attributes` to add inlet height to the platform variable, if this information is missing. There's a warning message, telling users this is happening. This leads to long error messages for models with lots of sites, so maybe could be improved!
- In `slice_mf`, repeated sites (e.g. TAC-100 and TAC-185) are (optionally) combined, so they can be plotted in one timeseries.
- Updated `plot_sites_timeseries` so this works with updated functions above, and to fix x-axis labels.

There's also a couple of other minor fixes to unrelated functions:

- `plot_sites_timeseries` would fail if only one model was included (at some point it uses the number of models to set x axis spacing, and this failed when len(models) = 1). So I've put a quick fix in for this.
- If any of the mf plotting functions can't find a variable named `percentile_` it will instead use `stdev_`, and vice versa. This way we can plot a mixture of models that use only one of these variables. I've put a warning in the function output, telling the user if this is happening.