### PR TITLE
Fix usage of subdirectories inside /path/to/data/<inverseModel>/<species>/

### DIFF
--- a/fluxy/config.py
+++ b/fluxy/config.py
@@ -134,7 +134,9 @@ def set_model_colors(models: list[str]) -> dict[str, list]:
 
     Args:
         models (list of str):
-            Keys specifying model names, e.g. ['intem','elris']
+            Model name tags specifying model runs,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable,
+            e.g. ['InTEM_NAME_EUROPE_EDGAR','ELRIS_NAME_EUROPE_EDGAR']
 
     Returns:
         model_colors (dict of lists):
@@ -204,7 +206,9 @@ def set_model_labels(
 
     Args:
         models (list of str):
-            Keys specifying model names, e.g. ['intem','elris']
+            Model name tags specifying model runs,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable,
+            e.g. ['InTEM_NAME_EUROPE_EDGAR','ELRIS_NAME_EUROPE_EDGAR']
         config_data (dict of dict):
             Dictionary with settings read from json file.
             Use json filenames as keys.

--- a/fluxy/config.py
+++ b/fluxy/config.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,9 @@ def set_model_colors(models: list[str]) -> dict[str, list]:
 
     # Get unique inversion systems
     # dict.fromkeys() is used because it conserves the order of the models
-    unique_models = list(dict.fromkeys(m.split("_")[0] for m in models))
+    unique_models = list(
+        dict.fromkeys(os.path.basename(m).split("_")[0] for m in models)
+    )
     n_unique_models = len(unique_models)
 
     if n_unique_models == 1:
@@ -173,7 +176,7 @@ def set_model_colors(models: list[str]) -> dict[str, list]:
         index_colors_max = [len(color_palette[i]) for i in color_palette]
 
         for m in models:
-            model_name = m.split("_")[0]
+            model_name = os.path.basename(m).split("_")[0]
             i = unique_models.index(model_name)
 
             if i == max_color_groups:

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -197,7 +197,9 @@ def read_model_output(
         species (str):
             Gas species, e.g. 'ch4'.
         models (list of str):
-            Keys specifying model names, e.g. ['intem','elris']
+            Model name tags specifying model runs,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable,
+            e.g. ['InTEM_NAME_EUROPE_EDGAR','ELRIS_NAME_EUROPE_EDGAR']
         config_data (dict of dict):
             Dictionary with settings read from json file.
             Use json filenames as keys.
@@ -272,7 +274,9 @@ def read_flux_total_fgases(
         species (str):
             'all_hfc' or 'all_pfc'
         models (list of str):
-            Keys specifying model names, e.g. ['intem','elris']
+            Model name tags specifying model runs,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable,
+            e.g. ['InTEM_NAME_EUROPE_EDGAR','ELRIS_NAME_EUROPE_EDGAR']
         regions (list of str):
             Region names used to extract fluxes. Only these regions can then be plotted.
         config_data (dict of dict):
@@ -439,7 +443,9 @@ def create_flux_total_fgases(ds_all, species, regions, models):
         species (str):
             'all_hfc' or 'all_pfc'
         models (list of str):
-            Keys specifying model names, e.g. ['intem','elris']
+            Model name tags specifying model runs,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable,
+            e.g. ['InTEM_NAME_EUROPE_EDGAR','ELRIS_NAME_EUROPE_EDGAR']
         regions (list of str):
             Region names used to extract fluxes. Only these regions can then be plotted.
 
@@ -543,7 +549,8 @@ def edit_vars_and_attributes(
         ds (xarray dataset):
             xarray dataset with model data.
         model (str):
-            Model name tag corresponding to ds.
+            Model name tag corresponding to ds,
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable
         frequency (str):
             Frequency of the inversion results present in the dataset.
             Options for "monthly" and "yearly".

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -140,7 +140,8 @@ def get_filename(
     """
 
     # Get file name tags
-    name_tags = model.split("_")
+    sub_dir, name_tags = os.path.split(model)
+    name_tags = name_tags.split("_")
     model_name = name_tags[0]
 
     # Replace parameter tags by dict values in config
@@ -172,6 +173,7 @@ def get_filename(
         data_dir
         / model_name
         / species
+        / sub_dir
         / f"{model_filename}_{species_print}_{period}{file_pattern}"
     )
 
@@ -572,7 +574,8 @@ def edit_vars_and_attributes(
     ds = ds.rename(name_dict)
 
     # Get model name
-    m0 = model.split("_")[0].lower()
+    filename_tags = os.path.basename(model)
+    m0 = filename_tags.split("_")[0].lower()
 
     # Fix flux dataset
     if file_type == "flux":

--- a/fluxy/operators/convert.py
+++ b/fluxy/operators/convert.py
@@ -20,6 +20,7 @@ def scale_variables(
     Args:
         model (str):
             Name tag of the model being scaled.
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable
         ds_model (xarray dataset):
             Sliced dataset with mf data from model.
         species_info (dictionary of str):

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -405,7 +405,8 @@ def plot_histogram(
         ds (xarray dataset):
             Dataset with results from a particular model.
         model (str):
-            Model name to which the dataset ds refers to.
+            Model name tag to which the dataset ds refers to.
+            i.e. '<inversionModel>_<optional_identifying_tags>', preceded by subdirectory if applicable
         vars_to_plot (list of str):
             Variables plotted in the timeseries plot.
             These variables are directly plotted in the histogram if diff_include is None.


### PR DESCRIPTION
The first element of the filename is expected to be the inverse model name (e.g. "ELRIS" in "ELRIS_NAME_EUROPE_EDGAR"). Therefore, in the code, the inverse model name was obtained with `split("_")[0]`. This info is used to know the folder name where the data is stored: `/path/to/data/<inverseModel>/<species>/`

This was a problem when creating sub-directories inside `<inverseModel>/<species>/` and trying to access the data with `models = ["subdirectory/ELRIS_NAME_EUROPE_EDGAR"]`. The code would only work if `subdirectory` had the format `<inverseModel>_<etc_etc>`

Therefore, the code was modified so that `split("_")[0]` is applied to the basename.
This allows the use of sub-directories with any name (e.g. "HFC_paper", or "Intercomparison_paper").