### PR TITLE
Check for NaNs in mf_observed only

### DIFF
--- a/fluxy/operators/mf.py
+++ b/fluxy/operators/mf.py
@@ -154,8 +154,7 @@ def stats_mf(
     # Compute stats for all sites and all models
     for site in sites_all:
         for model, ds in ds_all.items():
-            # Remove the NaNs
-            ds = ds.dropna("index")
+            # Mask by site
             site_index = get_site_index(ds, site)
             if site_index is None:
                 continue
@@ -163,6 +162,9 @@ def stats_mf(
             if not mask_site.any():
                 continue
             ds_site = ds.where(mask_site, drop=True)
+
+            # Remove indexes with no obs
+            ds_site = ds_site.dropna("index", subset=["mf_observed"])
 
             # select what to compare
             if stats_type == "prior":


### PR DESCRIPTION
This solves issue #149
At this stage in the code, there are only assimilated time stamps. Therefore, there should be no NaNs in mf_observed/mf_prior/mf_posterior/mf_bc_posterior/mf_bc_prior. However, when converting from the old format to the new format, some NaNs may remain. In the old format, whenever mf_observed is NaN, the simulated variables are also NaN and vice versa. Therefore, checking for NaNs in mf_observed is sufficient to solve the issue.