### PR TITLE
fix calculating prior uncertainty for regions from countries

### DIFF
--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -88,8 +88,8 @@ def extract_region_flux(
                 ds_region["sigma_prior"] = np.sqrt(
                     (
                         (
-                            ds["flux_total_prior_country"]
-                            - ds["percentile_flux_total_prior_country"].isel(
+                            ds_region["flux_total_prior_country"]
+                            - ds_region["percentile_flux_total_prior_country"].isel(
                                 percentile=min_percentile_index
                             )
                         )
@@ -98,7 +98,7 @@ def extract_region_flux(
                 )
             elif "stdev_flux_total_prior_country" in ds.variables:
                 ds_region["sigma_prior"] = np.sqrt(
-                    ((ds["stdev_flux_total_prior_country"]) ** 2).sum(dim="country")
+                    ((ds_region["stdev_flux_total_prior_country"]) ** 2).sum(dim="country")
                 )
             else:
                 ds_region["sigma_prior"] = xr.zeros_like(

--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -84,7 +84,7 @@ def extract_region_flux(
                     dim="country", keep_attrs=True
                 )
 
-            if "percentile_flux_total_prior_country" in ds.variables:
+            if "percentile_flux_total_prior_country" in ds_region.variables:
                 ds_region["sigma_prior"] = np.sqrt(
                     (
                         (
@@ -96,7 +96,7 @@ def extract_region_flux(
                         ** 2
                     ).sum(dim="country")
                 )
-            elif "stdev_flux_total_prior_country" in ds.variables:
+            elif "stdev_flux_total_prior_country" in ds_region.variables:
                 ds_region["sigma_prior"] = np.sqrt(
                     ((ds_region["stdev_flux_total_prior_country"]) ** 2).sum(dim="country")
                 )
@@ -105,7 +105,7 @@ def extract_region_flux(
                     ds_region["flux_total_prior_country"]
                 ).sum(dim="country")
 
-            if "covariance_flux_total_posterior_country" in ds.variables:
+            if "covariance_flux_total_posterior_country" in ds_region.variables:
                 ds_region["sigma_posterior"] = np.sqrt(
                     ds_region["covariance_flux_total_posterior_country"]
                     .sum(dim="country")


### PR DESCRIPTION
fluxy.operators.regions.extract_region_flux sums up covariances of countries to get the variance of a region. In that function, the selection of countries was not applied consistently, leading to wrong prior uncertainties.