### PR TITLE
Bug fix for adding separate BEL and LUX fluxes, so this works with both new and old InTEM files

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -629,7 +629,8 @@ def edit_vars_and_attributes(
                     ds[var].attrs["units"] = ds[var].attrs["unit"]
                     ds[var].attrs.pop("unit")
 
-            ds = ds.rename({"countrynumber": "country"})
+            if "countrynumber" in ds:
+                ds = ds.rename({"countrynumber": "country"})
 
             if "BEL-LUX" in ds.country and (
                 "BEL" not in ds.country and "LUX" not in ds.country
@@ -656,7 +657,7 @@ def edit_vars_and_attributes(
                 del ds_bel["country"]
                 del ds_lux["country"]
 
-                ds_bel["countryname"] = xr.DataArray(
+                ds_bel["country_merge"] = xr.DataArray(
                     data=[
                         "BELGIUM",
                     ]
@@ -665,10 +666,10 @@ def edit_vars_and_attributes(
                         "time",
                     ],
                     coords={"time": ds_bel.time},
-                    attrs=ds.countryname.attrs,
+                    attrs=ds['country'].attrs,
                 )
-
-                ds_lux["countryname"] = xr.DataArray(
+                
+                ds_lux["country_merge"] = xr.DataArray(
                     data=[
                         "LUXEMBOURG",
                     ]
@@ -677,14 +678,16 @@ def edit_vars_and_attributes(
                         "time",
                     ],
                     coords={"time": ds_lux.time},
-                    attrs=ds.countryname.attrs,
+                    attrs=ds['country'].attrs,
                 )
-
+                
                 ds_bellux = xr.concat(
                     [ds_bel, ds_lux], pd.Index(["BEL", "LUX"], name="country")
                 )
-                ds = xr.merge([ds, ds_bellux])
 
+                ds = xr.merge([ds, ds_bellux])
+                ds = ds.drop_vars("country_merge")
+                
         elif m0 == "rhime":
             ds["country"] = [
                 regions_info["country_codes"].get(x, x) for x in ds["country"].values


### PR DESCRIPTION
Code previously had hardcoded fixes for InTEMs `countryname` and `countrynumber` variables. These fixes aren't required with InTEM's new-format netcdfs, so these fixes have been made optional (based on presence of these variables). This fix was also required for the part of the code that added separate BEL and LUX fluxes to InTEM's data (as InTEM only outputs BEL-LUX fluxes). The code can now read in both new and old format InTEM netcdfs.