### PR TITLE
temporary fix for repeated TAC timestamps bug in InTEM files

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -875,6 +875,12 @@ def edit_vars_and_attributes(
             # Fill intake_height and stdev_mf_model with fake values
             ds["intake_height"][:] = 0
             ds["stdev_mf_model"][:] = 0
+        if m0 == "intem":
+            # Set assimilation_flag to zero is mf_observed = NaN
+            mask = np.isnan(ds["mf_observed"])
+            if any(mask):
+                ds["assimilation_flag"][mask] = 0
+                logger.warning(f"Masking out nan values in {model}, as a quick fix for a bug in InTEM concentration files.")
 
     if file_type == DataTypes.EDDY_FLUX:
         # check some eddy flux variables

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -248,13 +248,6 @@ def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
 
     mask = ds["number_of_identifier"] == site_index
     ds = ds.where(mask, drop=True)
-    
-    #quick fix for bug in InTEM conc files with repeated TAC timestamps
-    if site == "TAC" and "InTEM" in ds.attrs["source"]:
-        if np.where(ds['time'] == ds['time'][0])[0].shape[0] > 1:
-            logger.warning(f"Masking out nan values for TAC, as a quick fix for a bug in InTEM concentration files.")
-            mask = np.isnan(ds["mf_observed"])
-            ds["assimilation_flag"][mask] = 0
 
     return ds
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -248,6 +248,12 @@ def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
 
     mask = ds["number_of_identifier"] == site_index
     ds = ds.where(mask, drop=True)
+    
+    #quick fix for bug in InTEM conc files with repeated TAC timestamps
+    if site == "TAC" and "InTEM" in ds.attrs["source"]:
+        logger.warning(f"Masking out nan values for TAC, as a quick fix for a bug in InTEM concentration files.")
+        mask = np.isnan(ds["mf_observed"])
+        ds["assimilation_flag"][mask] = 0
 
     return ds
 

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -251,9 +251,10 @@ def slice_site(ds: xr.Dataset, site: str) -> xr.Dataset:
     
     #quick fix for bug in InTEM conc files with repeated TAC timestamps
     if site == "TAC" and "InTEM" in ds.attrs["source"]:
-        logger.warning(f"Masking out nan values for TAC, as a quick fix for a bug in InTEM concentration files.")
-        mask = np.isnan(ds["mf_observed"])
-        ds["assimilation_flag"][mask] = 0
+        if np.where(ds['time'] == ds['time'][0])[0].shape[0] > 1:
+            logger.warning(f"Masking out nan values for TAC, as a quick fix for a bug in InTEM concentration files.")
+            mask = np.isnan(ds["mf_observed"])
+            ds["assimilation_flag"][mask] = 0
 
     return ds
 


### PR DESCRIPTION
This is a short term fix to allow for concentration comparisons when there are bugs in InTEM's concentration files (repeated TAC timestamps)