### PR TITLE
Remove "total" from labels

### DIFF
--- a/fluxy/plots/flux_map.py
+++ b/fluxy/plots/flux_map.py
@@ -718,7 +718,7 @@ def plot_flux_map_over_time(
         ds,
         species_info,
         var,
-        sector=sector,
+        sector=sector if sector != "total" else "",
         format=["variable", "species", "sector", "units"],
     )
     add_colorbar(

--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -399,7 +399,7 @@ def plot_country_flux(
                 )
 
         ax.set_ylabel(
-            f"{s_data.get(species, {}).get('species_print', species)} {sector.title()}"
+            f"{s_data.get(species, {}).get('species_print', species)} {sector.title() if sector != 'total' else ''}"
             f" ({unit.replace('2','$_{{2}}$').replace('-1','$^{{-1}}$')})"
         )
 


### PR DESCRIPTION
I find a bit annoying to have the word "total" in all the labels. Would it be ok to suppress it?