### PR TITLE
fixing error with unkown uncertainty variables 

### DIFF
--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -244,22 +244,20 @@ def plot_timeseries(
 
                 # Accept both percentile and stdev as uncertainty variables
                 if unc_var not in ds_plot.keys():
+                    unc_var_in = unc_var
                     if "percentile" in unc_var:
-                        unc_var_in = unc_var
                         unc_var = unc_var.replace("percentile", "stdev")
 
                     elif "stdev" in unc_var:
-                        unc_var_in = unc_var
                         unc_var = unc_var.replace("stdev", "percentile")
 
                     if unc_var not in ds_plot.keys():
                         raise KeyError(
                             f"Variables {unc_var_in} and {unc_var} not found in {m}."
                         )
-                    else:
-                        logger.warning(
-                            f"Variable {unc_var_in} not found in {m} so reading uncert from {unc_var}."
-                        )
+                    logger.warning(
+                        f"Variable {unc_var_in} not found in {m} so reading uncert from {unc_var}."
+                    )
 
                 kwargs = {
                     "color": plot_color,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 import fluxy
 from fluxy.config import set_print_settings
 from fluxy.config import set_model_colors
@@ -198,6 +199,23 @@ def test_mf_timeseries_no_hist():
         diff_include=["mf_posterior"],
         y_lim=None,
     )
+
+
+def test_mf_timeseries_bad_uncertainty_var():
+    with pytest.raises(KeyError):
+        fig = plot_mf_timeseries(
+            ds_all_mf_sliced,
+            species,
+            site,
+            model_colors,
+            model_labels,
+            config_data,
+            annotate_coords,
+            include={"mf_observed": None, "mf_posterior": "invalid_mf_posterior"},
+            diff_include=["mf_posterior"],
+            y_lim=None,
+        )
+
 
 
 def test_obs_modelled_together():


### PR DESCRIPTION
There was an error when the variable is not know. 

The `unc_var_in` was not defined and thus the KeyError could not be thrown. 

Now it should be fixed with a test for the expected beahviour.