### PR TITLE
Alternative flux filename

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -320,14 +320,14 @@ def read_model_output(
 
         # Check if file exists
         if not filepath.is_file():
-            logger.warning(f"Cannot find {file_type.value} file: {filepath}. Will try altnative name.")
             #  alternative filename with _flux ending
             if file_type==DataTypes.FLUX:
+                logger.warning(f"Cannot find {file_type.value} file: {filepath}. Will try alternative name.")
                 filepath = get_filename(
                 m,
                 species,
                 period_str,
-                file_pattern(file_type, alternativ=True),
+                file_pattern(file_type, alternative=True),
                 config_data,
                 data_dir,
                 read_standard_run,

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -320,6 +320,7 @@ def read_model_output(
 
         # Check if file exists
         if not filepath.is_file():
+            logger.warning(f"Cannot find {file_type.value} file: {filepath}. Will try altnative name.")
             #  alternative filename with _flux ending
             if file_type==DataTypes.FLUX:
                 filepath = get_filename(

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -320,8 +320,20 @@ def read_model_output(
 
         # Check if file exists
         if not filepath.is_file():
-            logger.warning(f"Cannot find {file_type.value} file: {filepath}.")
-            continue
+            #  alternative filename with _flux ending
+            if file_type==DataTypes.FLUX:
+                filepath = get_filename(
+                m,
+                species,
+                period_str,
+                file_pattern(file_type, alternativ=True),
+                config_data,
+                data_dir,
+                read_standard_run,
+            )
+            if not filepath.is_file():
+                logger.warning(f"Cannot find {file_type.value} file: {filepath}.")
+                continue
 
         # Read file
         logger.info(f"Reading {file_type} file: {filepath}")
@@ -664,6 +676,13 @@ def edit_vars_and_attributes(
     # Fix flux dataset
     if file_type == DataTypes.FLUX:
 
+        if "countrynumber" in ds.dims.keys():
+            ds["country"] = ds["country"].astype("str")
+            ds = ds.set_index(countrynumber="country").rename(
+                    {"countrynumber": "country"}
+                )
+
+        
         # Apply model specific corrections
         if m0 in ("elris", "flexinvert"):
             # Fix for legacy files
@@ -854,20 +873,20 @@ def edit_vars_and_attributes(
                 coords=ds["platform"].coords,
             )
         if m0 == "flexinvert":
-            ds["mf_observed"].attrs["units"] = "ppt"
+            #ds["mf_observed"].attrs["units"] = "ppt"
             ds["mf_observed"].attrs["longname"] = "observed_mole_fraction"
-            ds["mf_prior"].attrs["units"] = "ppt"
+            #ds["mf_prior"].attrs["units"] = "ppt"
             ds["mf_prior"].attrs["longname"] = "apriori_simulated_mole_fraction"
-            ds["mf_posterior"].attrs["units"] = "ppt"
+            #ds["mf_posterior"].attrs["units"] = "ppt"
             ds["mf_posterior"].attrs["longname"] = "aposteriori_simulated_mole_fraction"
-            ds["mf_bc_prior"] = ds["Ypri_bkg"]
-            ds["mf_bc_prior"].attrs["units"] = "ppt"
+            #ds["mf_bc_prior"] = ds["Ypri_bkg"]
+            #ds["mf_bc_prior"].attrs["units"] = "ppt"
             ds["mf_bc_prior"].attrs[
                 "longname"
             ] = "apriori_simulated_boundary_condition_mole_fraction"
-            ds["mf_bc_prior"] = ds["Ypri_bkg"]
-            ds["mf_bc_posterior"] = ds["Ypost_bkg"]
-            ds["mf_bc_posterior"].attrs["units"] = "ppt"
+            # ds["mf_bc_prior"] = ds["Ypri_bkg"]
+            # ds["mf_bc_posterior"] = ds["Ypost_bkg"]
+            #ds["mf_bc_posterior"].attrs["units"] = "ppt"
             ds["mf_bc_posterior"].attrs[
                 "longname"
             ] = "aposteriori_simulated_boundary_condition_mole_fraction"

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -676,13 +676,6 @@ def edit_vars_and_attributes(
     # Fix flux dataset
     if file_type == DataTypes.FLUX:
 
-        if "countrynumber" in ds.dims.keys():
-            ds["country"] = ds["country"].astype("str")
-            ds = ds.set_index(countrynumber="country").rename(
-                    {"countrynumber": "country"}
-                )
-
-        
         # Apply model specific corrections
         if m0 in ("elris", "flexinvert"):
             # Fix for legacy files
@@ -873,20 +866,20 @@ def edit_vars_and_attributes(
                 coords=ds["platform"].coords,
             )
         if m0 == "flexinvert":
-            #ds["mf_observed"].attrs["units"] = "ppt"
+            ds["mf_observed"].attrs["units"] = "ppt"
             ds["mf_observed"].attrs["longname"] = "observed_mole_fraction"
-            #ds["mf_prior"].attrs["units"] = "ppt"
+            ds["mf_prior"].attrs["units"] = "ppt"
             ds["mf_prior"].attrs["longname"] = "apriori_simulated_mole_fraction"
-            #ds["mf_posterior"].attrs["units"] = "ppt"
+            ds["mf_posterior"].attrs["units"] = "ppt"
             ds["mf_posterior"].attrs["longname"] = "aposteriori_simulated_mole_fraction"
-            #ds["mf_bc_prior"] = ds["Ypri_bkg"]
-            #ds["mf_bc_prior"].attrs["units"] = "ppt"
+            ds["mf_bc_prior"] = ds["Ypri_bkg"]
+            ds["mf_bc_prior"].attrs["units"] = "ppt"
             ds["mf_bc_prior"].attrs[
                 "longname"
             ] = "apriori_simulated_boundary_condition_mole_fraction"
-            # ds["mf_bc_prior"] = ds["Ypri_bkg"]
-            # ds["mf_bc_posterior"] = ds["Ypost_bkg"]
-            #ds["mf_bc_posterior"].attrs["units"] = "ppt"
+            ds["mf_bc_prior"] = ds["Ypri_bkg"]
+            ds["mf_bc_posterior"] = ds["Ypost_bkg"]
+            ds["mf_bc_posterior"].attrs["units"] = "ppt"
             ds["mf_bc_posterior"].attrs[
                 "longname"
             ] = "aposteriori_simulated_boundary_condition_mole_fraction"

--- a/fluxy/types.py
+++ b/fluxy/types.py
@@ -32,10 +32,10 @@ def file_pattern(
     """
     if file_type == DataTypes.FLUX:
 
-        # Default file type
-        return ".nc"
         if alternative:
             return "_flux.nc"
+        # Default file type
+        return ".nc"
     elif file_type == DataTypes.CONCENTRATION:
         return "_concentrations.nc"
     else:

--- a/fluxy/types.py
+++ b/fluxy/types.py
@@ -34,7 +34,7 @@ def file_pattern(
 
         # Default file type
         return ".nc"
-        if alternative
+        if alternative:
             return "_flux.nc"
     elif file_type == DataTypes.CONCENTRATION:
         return "_concentrations.nc"

--- a/fluxy/types.py
+++ b/fluxy/types.py
@@ -14,11 +14,28 @@ class DataTypes(Enum):
     EDDY_FLUX = "eddy_flux"
 
 
-def file_pattern(file_type: DataTypes) -> str:
-    """Returns the ending pattern for the given file type."""
+def file_pattern(
+    file_type: DataTypes, 
+    alternative: bool = False
+) -> str:
+    """
+    Returns the ending pattern for the given file type.
+    Args:
+        file_type (DataTypes):
+            Type of file (flux or conentration as defined in class DataTypes)
+        alternative (bool): 
+            If true an alternative file ending is used for flux files. 
+
+    Returns:
+        ds_all (str):
+           filename ending depding on data type.  
+    """
     if file_type == DataTypes.FLUX:
+
         # Default file type
         return ".nc"
+        if alternative
+            return "_flux.nc"
     elif file_type == DataTypes.CONCENTRATION:
         return "_concentrations.nc"
     else:

--- a/fluxy/types.py
+++ b/fluxy/types.py
@@ -22,13 +22,13 @@ def file_pattern(
     Returns the ending pattern for the given file type.
     Args:
         file_type (DataTypes):
-            Type of file (flux or conentration as defined in class DataTypes)
+            Type of file (flux or concentration as defined in class DataTypes)
         alternative (bool): 
             If true an alternative file ending is used for flux files. 
 
     Returns:
         ds_all (str):
-           filename ending depding on data type.  
+           filename ending depending on data type.  
     """
     if file_type == DataTypes.FLUX:
 


### PR DESCRIPTION
I suggest to change our default filenames for the flux files to "_flux.nc" 

In order to be compatible, I added this as an alternative ending in file_pattern, which is then called in read_model_output

Could this be merged with priority? I would like to submit this year's PARIS results with the new file endings. 