### PR TITLE
Bugfix percentile dimension order

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -807,6 +807,7 @@ def edit_vars_and_attributes(
                 attrs=ds[var_to_change].attrs,
             )
 
+    # Fix concentration/eddy flux datasets
     elif file_type in (DataTypes.CONCENTRATION, DataTypes.EDDY_FLUX):
         # Ensure integer dtype
         ds["number_of_identifier"] = ds["number_of_identifier"].astype(int)
@@ -825,6 +826,9 @@ def edit_vars_and_attributes(
                 .stack({"index": ["number_of_identifier", "time"]})
                 .reset_index("index")
             )
+
+        # Reorder dimensions
+        ds = ds.transpose('index', 'percentile', ...)
 
         if "assimilation_flag" not in ds:
             # Add assimilation_flag if not present
@@ -901,6 +905,7 @@ def edit_vars_and_attributes(
                 ds["assimilation_flag"][mask] = 0
                 logger.info(f"Masking out nan values in {model}, as a quick fix for a bug in InTEM concentration files.")
 
+    # Fix eddy flux dataset
     if file_type == DataTypes.EDDY_FLUX:
         # check some eddy flux variables
         if "ecflux_observed" not in ds:

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -361,6 +361,9 @@ def read_model_output(
             logger.info(f"'species' attribute in dataset {m} ({current_species}) differs from species {species}. It is overwritten.")
             ds_all[m].attrs["species"] = species
 
+        # Load data to avoid thread.lock error
+        ds_all[m] = ds_all[m].load()
+
     return ds_all
 
 
@@ -828,7 +831,9 @@ def edit_vars_and_attributes(
             )
 
         # Reorder dimensions
-        ds = ds.transpose('index', 'percentile', ...)
+        for var in ds.data_vars:
+            if {'index', 'percentile'}.issubset(ds[var].dims):
+                ds[var] = ds[var].transpose('index', 'percentile', ...)
 
         if "assimilation_flag" not in ds:
             # Add assimilation_flag if not present

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -361,9 +361,6 @@ def read_model_output(
             logger.info(f"'species' attribute in dataset {m} ({current_species}) differs from species {species}. It is overwritten.")
             ds_all[m].attrs["species"] = species
 
-        # Load data to avoid thread.lock error
-        ds_all[m] = ds_all[m].load()
-
     return ds_all
 
 
@@ -829,11 +826,6 @@ def edit_vars_and_attributes(
                 .stack({"index": ["number_of_identifier", "time"]})
                 .reset_index("index")
             )
-
-        # Reorder dimensions
-        for var in ds.data_vars:
-            if {'index', 'percentile'}.issubset(ds[var].dims):
-                ds[var] = ds[var].transpose('index', 'percentile', ...)
 
         if "assimilation_flag" not in ds:
             # Add assimilation_flag if not present

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -180,6 +180,7 @@ def slice_mf(
 
         # Slice data according to site
         if site is not None:
+            ds_all[m] = ds_all[m].load() # Needed to avoid thread.lock error
             try:
                 ds_all[m] = slice_site(ds_all[m], site)
             except ValueError as e:

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -180,7 +180,6 @@ def slice_mf(
 
         # Slice data according to site
         if site is not None:
-            ds_all[m] = ds_all[m].load() # Needed to avoid thread.lock error
             try:
                 ds_all[m] = slice_site(ds_all[m], site)
             except ValueError as e:

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -266,8 +266,8 @@ def plot_timeseries(
                 # Define uncertainty band
                 flag_fill_between = False
                 if unc_var.split("_")[0] == "percentile":
-                    y1 = ds_plot[unc_var][0, :].values
-                    y2 = ds_plot[unc_var][1, :].values
+                    y1 = ds_plot[unc_var][:,0].values
+                    y2 = ds_plot[unc_var][:,1].values
                     flag_fill_between = True
                 elif unc_var.split("_")[-1] in ["prior", "posterior"]:
                     y1 = ds_plot[var].values - ds_plot[unc_var].values

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -266,8 +266,8 @@ def plot_timeseries(
                 # Define uncertainty band
                 flag_fill_between = False
                 if unc_var.split("_")[0] == "percentile":
-                    y1 = ds_plot[unc_var][:,0].values
-                    y2 = ds_plot[unc_var][:,1].values
+                    y1 = ds_plot[unc_var].isel(percentile=0).values
+                    y2 = ds_plot[unc_var].isel(percentile=0).values
                     flag_fill_between = True
                 elif unc_var.split("_")[-1] in ["prior", "posterior"]:
                     y1 = ds_plot[var].values - ds_plot[unc_var].values

--- a/fluxy/plots/mf_timeseries.py
+++ b/fluxy/plots/mf_timeseries.py
@@ -267,7 +267,7 @@ def plot_timeseries(
                 flag_fill_between = False
                 if unc_var.split("_")[0] == "percentile":
                     y1 = ds_plot[unc_var].isel(percentile=0).values
-                    y2 = ds_plot[unc_var].isel(percentile=0).values
+                    y2 = ds_plot[unc_var].isel(percentile=1).values
                     flag_fill_between = True
                 elif unc_var.split("_")[-1] in ["prior", "posterior"]:
                     y1 = ds_plot[var].values - ds_plot[unc_var].values


### PR DESCRIPTION
While the cdl template specifies (index, percentile) as the dimensions of variables `percentile_*`, fluxy was assuming the opposite order. Moreover, when converting from the old to the new format, the dimensions order was wrongly set (in agreement with fluxy plotting, but not with the template).

The dimensions order is now exchanged in `edit_vars_and_attributes` and the plotting function `plot_timeseries` was updated accordingly.

The only problem is that I'm having a thread.lock error when slicing the data. Therefore, I now load the data immediately after reading, which might not be ideal memory-wise. @lionel42 is there a better way?