### PR TITLE
Fix bug from country attributes for all_hfc with multiple regions

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -687,7 +687,7 @@ def create_flux_total_fgases(ds_all, species, regions, models):
                 ds_summed.append(ds_unc)
             ds_list.append(xr.merge(ds_summed, combine_attrs="no_conflicts"))
 
-        ds_tmp = xr.concat(ds_list, dim="country", combine_attrs="drop_conflicts")
+        ds_tmp = xr.concat(ds_list, dim="country", combine_attrs="no_conflicts")
         ds_tmp.attrs["species"] = species
 
         ds_output[model] = ds_tmp

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -687,7 +687,7 @@ def create_flux_total_fgases(ds_all, species, regions, models):
                 ds_summed.append(ds_unc)
             ds_list.append(xr.merge(ds_summed, combine_attrs="no_conflicts"))
 
-        ds_tmp = xr.concat(ds_list, dim="country", combine_attrs="no_conflicts")
+        ds_tmp = xr.concat(ds_list, dim="country", combine_attrs="drop_conflicts")
         ds_tmp.attrs["species"] = species
 
         ds_output[model] = ds_tmp

--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -48,7 +48,13 @@ def extract_region_flux(
     max_percentile_index = 1
 
     if all([("all" in ds.attrs.get("species", "")) for ds in ds_all.values()]):
-        ds_output = {m: ds.sel({"country": country_search}) for m, ds in ds_all.items()}
+        ds_output = {
+            m: ds.sel(country=country_search).assign_attrs(
+                sector=sector,
+                country=country
+            )
+            for m, ds in ds_all.items()
+        }
         return ds_output
 
     target_vars = [

--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -47,7 +47,9 @@ def extract_region_flux(
     max_percentile_index = 1
 
     if all([("all" in ds.attrs.get("species", "")) for ds in ds_all.values()]):
-        ds_output = {m: ds.sel({"country": country_search}) for m, ds in ds_all.items()}
+        for m, ds in ds_all.items():
+            ds_output[m] = ds.sel({"country": country_search})
+            ds_output[m].attrs['country'] = country
         return ds_output
 
     target_vars = [

--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -16,7 +16,7 @@ def extract_region_flux(
     regions_info: dict[str, str],
     keep_country_dim: bool = False,
     sector: str = 'total'
-) -> dict[str, xr.Dataset]:
+    ) -> dict[str, xr.Dataset]:
     """
     Finds the index of a chosen region name and extracts the country flux
     variables for this region.
@@ -29,7 +29,8 @@ def extract_region_flux(
             chosen dates.
         country: name of the country to extract.
         regions_info: dictionary with country and region names (read from json file).
-        keep_country_dim: if True, re-put country dimension on the output datasets.
+        keep_country_dim: if True, re-put country dimension on the output datasets, else 
+            store the country (and sector) as attributes.
 
     Returns:
         ds_output: dictionnary of datasets. The dataset variables are :
@@ -47,9 +48,7 @@ def extract_region_flux(
     max_percentile_index = 1
 
     if all([("all" in ds.attrs.get("species", "")) for ds in ds_all.values()]):
-        for m, ds in ds_all.items():
-            ds_output[m] = ds.sel({"country": country_search})
-            ds_output[m].attrs['country'] = country
+        ds_output = {m: ds.sel({"country": country_search}) for m, ds in ds_all.items()}
         return ds_output
 
     target_vars = [
@@ -178,8 +177,8 @@ def extract_region_flux(
                     ]
                 }
             )
-        
-        ds_region.attrs.update({"sector": sector, "country": country})
+        else:
+            ds_region.attrs.update({"sector": sector, "country": country})
 
         ds_output[m] = ds_region
 

--- a/fluxy/operators/regions.py
+++ b/fluxy/operators/regions.py
@@ -16,7 +16,7 @@ def extract_region_flux(
     regions_info: dict[str, str],
     keep_country_dim: bool = False,
     sector: str = 'total'
-    ) -> dict[str, xr.Dataset]:
+) -> dict[str, xr.Dataset]:
     """
     Finds the index of a chosen region name and extracts the country flux
     variables for this region.


### PR DESCRIPTION
* drop conflicting attributes in `create_flux_total_fgases` happening with the attribute 'country' when multiple regions are plotted
* add attribute 'country' in `extract_region_flux` needed for `res` dict dataframe in `add_posterior_plot`

- [x] close #241 