### PR TITLE
Add defaults

### DIFF
--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -367,10 +367,10 @@ def get_filename(
 
 
 def read_model_output(
-    data_dir: os.PathLike,
-    file_type: DataType,
-    species: str,
-    models: list[str],
+    data_dir: os.PathLike | None = None,
+    file_type: DataType | str = "flux",
+    species: str | None = None,
+    models: list[str] = [],
     config_data: dict[str, dict] = {},
     period: str | list[str | None] | None = None,
     add_sites_to_flux: bool = False,

--- a/fluxy/io.py
+++ b/fluxy/io.py
@@ -484,7 +484,8 @@ def read_model_output(
 
         # Overwrite species attributes
         current_species = ds_all[m].attrs.get("species", "not set")
-        if current_species != species:
+        ds_all[m].attrs["species"] = current_species
+        if species is not None and current_species != species:
             logger.info(
                 f"'species' attribute in dataset {m} ({current_species}) differs from species {species}. It is overwritten."
             )

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -55,9 +55,10 @@ def slice_flux(
 
     """
     ds_all_sliced = dict()
+    species_info = config_data.get("species_info",{})
 
     if species is not None:
-        species_info = config_data["species_info"][species]
+        species_info = species_info.get(species, None)
 
     if type(start_date) is str:
         start_date = [start_date] * len(ds_all.keys())

--- a/fluxy/operators/select.py
+++ b/fluxy/operators/select.py
@@ -55,10 +55,7 @@ def slice_flux(
 
     """
     ds_all_sliced = dict()
-    species_info = config_data.get("species_info",{})
-
-    if species is not None:
-        species_info = species_info.get(species, None)
+    species_info = config_data.get("species_info",{}).get(species, None)
 
     if type(start_date) is str:
         start_date = [start_date] * len(ds_all.keys())


### PR DESCRIPTION
Add defaults to all read_model_output variables.
Make species_info not mandatory in select.py

The default values are useful when data_dir is defined inside model_filepath_dict.