### PR TITLE
Add second y-axis to plot_country_flux

### DIFF
--- a/fluxy/operators/convert.py
+++ b/fluxy/operators/convert.py
@@ -296,3 +296,49 @@ def get_units_conversion_factor(
         )
 
     return unit_to_base / target_to_base * M_scaling
+
+
+def convert_units_co2eq(
+    from_unit: str, to_unit: str, species_info: dict
+) -> float:
+ 
+    """
+    Convert between units that may include 'CO2-eq'.
+    Wraps get_units_conversion_factor and applies species GWP when needed.
+
+    Units are expected to have the following format:
+        "<letters><(-)integer>" separated by spaces (e.g. "Tg CO2-eq yr-1")
+    """
+
+    def strip_co2eq(unit):
+        return unit.replace(" CO2-eq", "") if "CO2-eq" in unit else unit
+
+    from_base = strip_co2eq(from_unit)
+    to_base = strip_co2eq(to_unit)
+
+    # Base physical conversion
+    conversion_factor = get_units_conversion_factor(
+        from_unit=from_base,
+        to_unit=to_base
+    )
+
+    # Get GWP if needed
+    GWP = species_info.get("gwp", None)
+
+    from_is_co2eq = "CO2-eq" in from_unit
+    to_is_co2eq = "CO2-eq" in to_unit
+
+    # Adjust for CO2-eq conversions
+    if from_is_co2eq and not to_is_co2eq:
+        if not GWP:
+            raise ValueError(f"GWP missing for species '{species}'")
+        conversion_factor /= GWP
+        logger.info(f"Converting to mass of non CO2-eq using GWP = {GWP}.")
+
+    elif to_is_co2eq and not from_is_co2eq:
+        if not GWP:
+            raise ValueError(f"GWP missing for species '{species}'")
+        conversion_factor *= GWP
+        logger.info(f"Converting to mass of CO2-eq using GWP = {GWP}.")
+
+    return conversion_factor

--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -20,6 +20,7 @@ from fluxy.operators.rolling_mean import calc_rolling_mean
 from fluxy.operators.flux_timeseries_resample import resample_flux
 from fluxy.operators.flux_combine import combine_dataset
 from fluxy.operators.flux_prepare_inventory import retrieve_inventories
+from fluxy.operators.convert import convert_units_co2eq
 from fluxy.plots.utils import update_list_params
 
 logger = logging.getLogger(__name__)
@@ -863,6 +864,66 @@ def add_title(ax: Axes, country: str, r_data: dict, country_codes_as_titles: boo
     else:
         ax.set_title(f"{print_country}")
 
+def add_secondary_yaxis(
+    ax: Axes,
+    s_data: dict[str, dict],
+    species: str,
+    sector: str,
+    unit: str,
+    secondary_unit: str,
+):
+    """
+    Add a secondary y-axis to the plot, converting from `unit` 
+    to `secondary_unit`, including CO2-eq aware conversions.
+
+    Args:
+        ax: axis to add secondary y-axis to.
+        s_data: dictionnary containing species data. See configs/species_infos.json.
+        species: name of the species.
+        sector: name of sector plotted.
+        unit: original unit of data plotted.
+        secondary_unit: unit of the secondary y-axis.
+    """
+
+    # Get conversion factor between the two units
+    conversion_factor = convert_units_co2eq(
+        from_unit = unit, 
+        to_unit = secondary_unit, 
+        species_info = s_data.get(species, {})
+        )
+
+    # Define foward and backward conversion functions
+    def unit_to_secondary_unit(y):
+        return y * conversion_factor
+
+    def secondary_unit_to_unit(y):
+        return y / conversion_factor
+
+    # Create secondary y-axis
+    secax = ax.secondary_yaxis(
+        'right',
+        functions=(unit_to_secondary_unit, secondary_unit_to_unit)
+    )
+
+    # Styling
+    sec_color = 'darkred'
+    secax.tick_params(axis='y', colors=sec_color)
+    secax.spines['right'].set_color(sec_color)
+    secax.spines['right'].set_linewidth(1.5)
+
+    # Labeling
+    add_ylabel(
+        secax, 
+        s_data, 
+        species, 
+        secondary_unit, 
+        plot_type="country_plot", 
+        sector=sector
+        )
+    secax.yaxis.label.set_color("darkred")
+    secax.yaxis.label.set_rotation(270)
+    secax.yaxis.labelpad = 20
+
 
 def plot_country_flux(
     ds_all: dict[str, xr.Dataset],
@@ -895,6 +956,7 @@ def plot_country_flux(
     rolling_mean: bool | list[bool] = False,
     aggreg_month: bool = False,
     sector: str = "total",
+    secondary_units: str | None = None,
 ) -> Figure | tuple[Figure, dict[str, dict]]:
     """
     Timeseries plot of prior and posterior country fluxes, from list of
@@ -939,6 +1001,7 @@ def plot_country_flux(
         return_res: Wheter or not including a dictionnary with the results as output
         rolling_mean : If True, calculates a rolling mean (xx years) for each of the data to plot.
         aggreg_month: if True, plot the data aggregated by month. Used to study seasonnal cycle.
+        secondary_units: If provided, add a secondary y-axis with these units.
     Returns:
         fig: A plot per country/region.
         res_dict : If return_res, return also a dataframe containing the plotted results. The columns of this dataframe are "type" (possible values "prior"/"posterior"/"inventory"),
@@ -1038,6 +1101,17 @@ def plot_country_flux(
 
         # set ax title
         add_title(ax, country, r_data, country_codes_as_titles)
+
+        # add secondary axis
+        if secondary_units is not None:
+            add_secondary_yaxis(
+                ax=ax,
+                s_data=s_data,
+                species=species,
+                sector=sector,
+                unit=unit,
+                secondary_unit=secondary_units,
+            )
 
     add_ylim(axes, "country", plot_regions, plotted_data_df, fix_y_axes, set_global_leg)
     yearly_freq = (

--- a/scripts/PARIS_inversion_results.ipynb
+++ b/scripts/PARIS_inversion_results.ipynb
@@ -184,6 +184,7 @@
     "rolling_mean = False # If True, calculates a rolling mean of the data (insert a list of boolean of the same length as models to specify the models to smooth)\n",
     "sector = 'total'     # default 'total', otherwise chosen single sector plotted for all models\n",
     "aggreg_month = False     # if True, plot the fluxes aggregated by month. Only work with monthly data.\n",
+    "secondary_units = None # If not None, e.g. 'Gg yr-1', adds a secondary y axis with these units\n",
     "###################################\n",
     "\n",
     "fig = plot_country_flux(ds_all_flux_scaled,\n",
@@ -214,6 +215,7 @@
     "                        plot_resample_and_original=plot_resample_and_original,\n",
     "                        rolling_mean=rolling_mean,\n",
     "                        aggreg_month=aggreg_month,\n",
+    "                        secondary_units=secondary_units,\n",
     "                        return_res=True,sector=sector)"
    ]
   },
@@ -395,7 +397,6 @@
     "# To plot the histogram of Obs-variable, set \"diff_include\" to the desired variable to be subtracted\n",
     "diff_include = ['mf_posterior']\n",
     "\n",
-    
     "y_lim = None # to choose y-axis limits set y_lim=[min_value,max_value]\n",
     "aggreg_month = False # set to true to aggregate mf data by month and see the seasonnal cycle\n",
     "###################################\n",


### PR DESCRIPTION
Enable to add a second y-axis to plot_country_flux, using the new option secondary_units = 'Gg yr-1'.

- [x] closes #262 