### PR TITLE
Bugfix fluxmap

### DIFF
--- a/fluxy/operators/flux_map_resample.py
+++ b/fluxy/operators/flux_map_resample.py
@@ -268,18 +268,12 @@ def resample_over_dates_list(
     time_labels = []
     for group in np.unique(groups_da):
         group_times = ds.time.values[groups_da == group]  # Get times in this group
-        if len(group_times) == 1:
-            first_time = pd.to_datetime(group_times.min())
-            time_labels.append(
-            f"{first_time.strftime([[1:3], [7:9]])}"
-            )
-        else:
-            first_time = pd.to_datetime(group_times.min())
-            last_time = pd.to_datetime(group_times.max())
-            time_labels.append(
-                f"{first_time.strftime([[1:3], [7:9]])}—{last_time.strftime([[1:3], [7:9]])}"
-            )
-            
+        first_time = pd.to_datetime(group_times.min())
+        last_time = pd.to_datetime(group_times.max())
+        time_labels.append(
+            f"{first_time.strftime('%Y/%m')}—{last_time.strftime('%Y/%m')}"
+        )
+
     return ds_resampled, time_labels
 
 def resample_over_periods_list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "v2.0"
 dependencies = [
   "matplotlib",
   "xarray>=2023.08",
+  "h5py",
   "h5netcdf",
   "geopandas",
   "PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "hatchling.build"
 name = "fluxy"
 version = "v2.0"
 dependencies = [
-  "numpy>=1.26.4",
-  "pandas>=2.2.3",
+  "numpy==1.26.4",
+  "pandas==2.2.3",
   "matplotlib",
   "xarray>=2023.08",
   "h5py",
@@ -50,4 +50,5 @@ Homepage = "https://horizoneurope-paris.eu/"
 Documentation = "https://github.com/openghg/fluxy/blob/devel/README.md"
 Repository = "https://github.com/openghg/fluxy"
 "Bug Tracker" = "https://github.com/openghg/fluxy/issues"
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "hatchling.build"
 name = "fluxy"
 version = "v2.0"
 dependencies = [
+  "numpy>=1.26.4",
+  "pandas>=2.2.3",
   "matplotlib",
   "xarray>=2023.08",
   "h5py",
@@ -48,3 +50,4 @@ Homepage = "https://horizoneurope-paris.eu/"
 Documentation = "https://github.com/openghg/fluxy/blob/devel/README.md"
 Repository = "https://github.com/openghg/fluxy"
 "Bug Tracker" = "https://github.com/openghg/fluxy/issues"
+


### PR DESCRIPTION
- Revert labels to previous implementation (to be improved by Alice in a later PR)
- Add h5py, numpy and pandas to list of dependencies

**Note:**
The tests pass on GitHub with the following numpy/pandas dependencies:
"numpy==1.26.4"
"pandas==2.2.3"
 
If I don't specify the versions, the following were being installed:
numpy-2.4.2
pandas-3.0.0
 
And the tests were failing. Maybe we need to make the code compatible with the latest numpy/pandas in a later PR. If you agree with the current fix, I will create an issue for this.