### PR TITLE
Bug fix

### DIFF
--- a/fluxy/plots/flux_timeseries.py
+++ b/fluxy/plots/flux_timeseries.py
@@ -680,11 +680,11 @@ def add_ylim(
 
         max_cf.append(max_country)
 
-    for i, ax in enumerate(axes):
+    for max_i, ax in zip(max_cf, axes):
         if fix_y_axes:
             ax.set_ylim(0, np.nanmax(max_cf) * fac)
         else:
-            ax.set_ylim(0, max_cf[i] * fac)
+            ax.set_ylim(0, max_i * fac)
 
 
 def add_ylabel(


### PR DESCRIPTION
The for-loop over all axes was replaced by a for-loop over all axes that have a max value associated. This avoids an out-of-bounds error when there are more subplots than regions to plot (for example, when 5 regions are specified but a 3x3 figure is created).