### PR TITLE
Performance improvements for concentration data

### DIFF
--- a/fluxie/operators/select.py
+++ b/fluxie/operators/select.py
@@ -190,7 +190,7 @@ def slice_mf(
         if not keep_unassimilated:
             # Mask assimilated data only
             mask &= ds_all[m]["assimilation_flag"] == 1
-        ds_all[m] = ds_all[m].where(mask, drop=True)
+        ds_all[m] = ds_all[m].isel(index=mask)
 
         # Slice according to intake height
         if intake_height is not None:
@@ -279,7 +279,7 @@ def slice_site(
 
     mask = ds["number_of_identifier"].isin(site_indices)
     if mask.any():
-        ds = ds.where(mask, drop=True)
+        ds = ds.isel(index=mask)
         return ds
 
     msg = f"No data for any sites {sites} with indices {site_indices} in model {ds.attrs['exp_name']}."

--- a/fluxie/plots/mf_timeseries.py
+++ b/fluxie/plots/mf_timeseries.py
@@ -920,7 +920,7 @@ def plot_sites_timeseries(
                 data,
                 ".",
                 color=model_colors[m][0],
-                ms=5,
+                ms=3,
                 label=model_labels_copy[m],
             )
 

--- a/fluxie/plots/mf_timeseries.py
+++ b/fluxie/plots/mf_timeseries.py
@@ -915,11 +915,12 @@ def plot_sites_timeseries(
             if separate_by_height:
                 mask &= ds_all[m]["intake_height"] == height
             data = ds_all[m]["time"].where(mask, drop=True)
-            ax.scatter(
+            ax.plot(
                 (site_iter + model_offset * i - 0.5 + margin) * np.ones(data.size),
                 data,
-                c=model_colors[m][0],
-                s=2,
+                ".",
+                color=model_colors[m][0],
+                ms=5,
                 label=model_labels_copy[m],
             )
 

--- a/fluxie/plots/mf_timeseries.py
+++ b/fluxie/plots/mf_timeseries.py
@@ -918,9 +918,9 @@ def plot_sites_timeseries(
             ax.plot(
                 (site_iter + model_offset * i - 0.5 + margin) * np.ones(data.size),
                 data,
-                ".",
+                "o",
                 color=model_colors[m][0],
-                ms=3,
+                ms=1.4142,
                 label=model_labels_copy[m],
             )
 


### PR DESCRIPTION
Improve speed and reduce memory requirement for plotting concentration data:
- Use xr.Dataset.isel instead of xr.Dataset.where when applicable, since isel can be much faster.
- Use ax.plot instead of ax.scatter to plot data points which share the same size, marker and color. This significantly reduces the memory footprint.

Note: ax.plot uses different units to measure marker sizes. The provided marker size ("ms") should match approximatly.