### PR TITLE
Feature: Allow aligning grids with different spatial extent but matching coordinates

### DIFF
--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -150,20 +150,23 @@ def align_lat_lon(
     """
 
     # Check if coordinates agree exactly.
-    if all(ds_list[0][coord].equals(x[coord]) for x in ds_list[1:]):
+    dim_equal = all(ds_list[0][coord].equals(x[coord]) for x in ds_list[1:])
+    if dim_equal:
         return ds_list
 
     tolerance = 2e-4  # degrees
 
     # Select common range of coordinates if the coordinate sizes differ.
     ref_dim_size = ds_list[0][coord].size
-    if any(x[coord].size != ref_dim_size for x in ds_list[1:]):
+    dim_sizes_differ = any(x[coord].size != ref_dim_size for x in ds_list[1:])
+    if dim_sizes_differ:
         start = max(x[coord].values[0] for x in ds_list) - tolerance
         end = min(x[coord].values[-1] for x in ds_list) + tolerance
         ds_list = [x.sel({coord: slice(start, end)}) for x in ds_list]
         # Check if the coordinate sizes agree now.
         common_dim_size = ds_list[0][coord].size
-        if any(common_dim_size != x[coord].size for x in ds_list[1:]):
+        dim_sizes_differ = any(x[coord].size != common_dim_size for x in ds_list[1:])
+        if dim_sizes_differ:
             raise ValueError(
                 f"{coord} dimensions seem to be too different between the datasets for them to be combined."
             )

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -135,7 +135,7 @@ def align_lat_lon(
     ds_list: list[xr.Dataset],
     coord: Literal["latitude", "longitude"],
     rel_tolerance: float = 0.01,
-    min_rel_overlap: float = 0.02,
+    min_rel_overlap: float = 0.98,
 ) -> list[xr.Dataset]:
     """
     Check the latitude/longitude coordinate of a list of xarray datasets and align them.

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -135,7 +135,13 @@ def align_lat_lon(
     ds_list: list[xr.Dataset], coord: Literal["latitude", "longitude"]
 ) -> list[xr.Dataset]:
     """
-    Check the latitude/longitude coordinate of a list of xarray datasets and, if they differ, align them with the latitudes/longitudes of the first dataset in the list.
+    Check the latitude/longitude coordinate of a list of xarray datasets and align them.
+
+    If coordinates cover a different range, select the intersection.
+    If the coordinates agree approximately, align them with the
+    latitudes/longitudes of the first dataset in the list.
+    If the coordinates differ such that an interpolation is required,
+    raise a ValueError.
 
     Args:
         ds_list: list of xarray datasets to be latitude/longitude-aligned
@@ -143,22 +149,44 @@ def align_lat_lon(
         aligned_ds_list: list of xarray datasets latitude/longitude-aligned
     """
 
-    dim_equal = [ds_list[0][coord].equals(x[coord]) for x in ds_list[1:]]
-
-    if all(dim_equal):
+    # Check if coordinates agree exactly.
+    if all(ds_list[0][coord].equals(x[coord]) for x in ds_list[1:]):
         return ds_list
 
-    dim_close = [
-        np.allclose(ds_list[0][coord].values, x[coord].values) for x in ds_list[1:]
-    ]  # Small tolerance
-    if all(dim_close):
+    tolerance = 2e-4  # degrees
+
+    # Select common range of coordinates if the coordinate sizes differ.
+    ref_dim_size = ds_list[0][coord].size
+    if any(x[coord].size != ref_dim_size for x in ds_list[1:]):
+        start = max(x[coord].values[0] for x in ds_list) - tolerance
+        end = min(x[coord].values[-1] for x in ds_list) + tolerance
+        ds_list = [x.sel({coord: slice(start, end)}) for x in ds_list]
+        # Check if the coordinate sizes agree now.
+        common_dim_size = ds_list[0][coord].size
+        if any(common_dim_size != x[coord].size for x in ds_list[1:]):
+            raise ValueError(
+                f"{coord} dimensions seem to be too different between the datasets for them to be combined."
+            )
+        # Fail if the overlap of the area covered by all models is too small
+        if common_dim_size < 0.1 * ref_dim_size:
+            raise ValueError(
+                f"{coord} dimensions of the datasets cover too different ranges for them to be combined."
+            )
+
+    # Check if the coordinates agree approximately within the given tolerance.
+    reference = ds_list[0][coord].values
+    dim_close = all(
+        np.allclose(reference, x[coord].values, atol=tolerance) for x in ds_list[1:]
+    )
+    if dim_close:
+        # Use coordinates of first model as reference.
         aligned_ds_list = [ds_list[0]]
 
         for ds_p in ds_list[1:]:
             if ds_list[0][coord].equals(ds_p[coord]):
                 aligned_ds_list.append(ds_p)
                 continue
-
+            # Replace coordinate with coordinate of first model.
             ds_aligned = ds_p
             ds_aligned[coord] = ds_list[0][coord]
             aligned_ds_list.append(ds_p)

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -181,22 +181,23 @@ def align_lat_lon(
             )
 
     # Check if the coordinates agree approximately within the given tolerance.
-    reference = ds_list[0][coord].values
+    ds_ref = ds_list[0]
+    reference = ds_ref[coord].values
     dim_close = all(
         np.allclose(reference, x[coord].values, atol=tolerance) for x in ds_list[1:]
     )
     if dim_close:
         # Use coordinates of first model as reference.
-        aligned_ds_list = [ds_list[0]]
+        aligned_ds_list = [ds_ref]
 
         for ds_p in ds_list[1:]:
-            if ds_list[0][coord].equals(ds_p[coord]):
+            if ds_ref[coord].equals(ds_p[coord]):
                 aligned_ds_list.append(ds_p)
                 continue
             # Replace coordinate with coordinate of first model.
-            ds_aligned = ds_p
-            ds_aligned[coord] = ds_list[0][coord]
-            aligned_ds_list.append(ds_p)
+            ds_aligned = ds_p.copy(deep=False)
+            ds_aligned[coord] = ds_ref[coord]
+            aligned_ds_list.append(ds_aligned)
     else:
         raise ValueError(
             f"{coord} dimensions seem to be too different between the datasets for them to be combined."

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -132,7 +132,9 @@ def align_time(
 
 
 def align_lat_lon(
-    ds_list: list[xr.Dataset], coord: Literal["latitude", "longitude"]
+    ds_list: list[xr.Dataset],
+    coord: Literal["latitude", "longitude"],
+    rel_tolerance: float = 0.01,
 ) -> list[xr.Dataset]:
     """
     Check the latitude/longitude coordinate of a list of xarray datasets and align them.
@@ -145,6 +147,8 @@ def align_lat_lon(
 
     Args:
         ds_list: list of xarray datasets to be latitude/longitude-aligned
+        coord: coordinate name (latitude or longitude)
+        rel_tolerance: float, tolerance coordinates relative to grid spacing
     Returns:
         aligned_ds_list: list of xarray datasets latitude/longitude-aligned
     """
@@ -154,7 +158,7 @@ def align_lat_lon(
     if dim_equal:
         return ds_list
 
-    tolerance = 2e-4  # degrees
+    tolerance = rel_tolerance * abs(ds_list[0][coord].diff(coord).mean().item())
 
     # Select common range of coordinates if the coordinate sizes differ.
     ref_dim_size = ds_list[0][coord].size

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -135,6 +135,7 @@ def align_lat_lon(
     ds_list: list[xr.Dataset],
     coord: Literal["latitude", "longitude"],
     rel_tolerance: float = 0.01,
+    min_rel_overlap: float = 0.02,
 ) -> list[xr.Dataset]:
     """
     Check the latitude/longitude coordinate of a list of xarray datasets and align them.
@@ -149,6 +150,7 @@ def align_lat_lon(
         ds_list: list of xarray datasets to be latitude/longitude-aligned
         coord: coordinate name (latitude or longitude)
         rel_tolerance: float, tolerance coordinates relative to grid spacing
+        min_rel_overlap: float, minimum relative overlap of coordinates.
     Returns:
         aligned_ds_list: list of xarray datasets latitude/longitude-aligned
     """
@@ -175,16 +177,17 @@ def align_lat_lon(
                 f"{coord} dimensions seem to be too different between the datasets for them to be combined."
             )
         # Fail if the overlap of the area covered by all models is too small
-        if common_dim_size < 0.1 * ref_dim_size:
+        if common_dim_size < min_rel_overlap * ref_dim_size:
             raise ValueError(
-                f"{coord} dimensions of the datasets cover too different ranges for them to be combined."
+                f"{coord} dimensions of the datasets cover too different ranges for them to be combined (threshold: {min_rel_overlap:%}."
             )
 
     # Check if the coordinates agree approximately within the given tolerance.
     ds_ref = ds_list[0]
     reference = ds_ref[coord].values
     dim_close = all(
-        np.allclose(reference, x[coord].values, atol=tolerance) for x in ds_list[1:]
+        np.allclose(reference, x[coord].values, atol=tolerance, rtol=0)
+        for x in ds_list[1:]
     )
     if dim_close:
         # Use coordinates of first model as reference.

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -135,7 +135,7 @@ def align_lat_lon(
     ds_list: list[xr.Dataset],
     coord: Literal["latitude", "longitude"],
     rel_tolerance: float = 0.01,
-    min_rel_overlap: float = 0.98,
+    min_rel_overlap: float = 0.05,
 ) -> list[xr.Dataset]:
     """
     Check the latitude/longitude coordinate of a list of xarray datasets and align them.

--- a/fluxie/operators/flux_align_dataset.py
+++ b/fluxie/operators/flux_align_dataset.py
@@ -189,22 +189,21 @@ def align_lat_lon(
         np.allclose(reference, x[coord].values, atol=tolerance, rtol=0)
         for x in ds_list[1:]
     )
-    if dim_close:
-        # Use coordinates of first model as reference.
-        aligned_ds_list = [ds_ref]
-
-        for ds_p in ds_list[1:]:
-            if ds_ref[coord].equals(ds_p[coord]):
-                aligned_ds_list.append(ds_p)
-                continue
-            # Replace coordinate with coordinate of first model.
-            ds_aligned = ds_p.copy(deep=False)
-            ds_aligned[coord] = ds_ref[coord]
-            aligned_ds_list.append(ds_aligned)
-    else:
+    if not dim_close:
         raise ValueError(
             f"{coord} dimensions seem to be too different between the datasets for them to be combined."
         )
+    # Use coordinates of first model as reference.
+    aligned_ds_list = [ds_ref]
+
+    for ds_p in ds_list[1:]:
+        if ds_ref[coord].equals(ds_p[coord]):
+            aligned_ds_list.append(ds_p)
+            continue
+        # Replace coordinate with coordinate of first model.
+        ds_aligned = ds_p.copy(deep=False)
+        ds_aligned[coord] = ds_ref[coord]
+        aligned_ds_list.append(ds_aligned)
 
     return aligned_ds_list
 

--- a/tests/operators/test_align.py
+++ b/tests/operators/test_align.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from fluxie.operators.flux_align_dataset import align_lat_lon
+
+
+def _make_test_dataset(latitudes: np.ndarray, longitudes: np.ndarray) -> xr.Dataset:
+    data = np.arange(latitudes.size * longitudes.size).reshape(
+        1, latitudes.size, longitudes.size
+    )
+    return xr.Dataset(
+        {
+            "flux": (
+                ["time", "latitude", "longitude"],
+                data,
+            )
+        },
+        coords={
+            "time": np.array([np.datetime64("2024-01-01")]),
+            "latitude": latitudes,
+            "longitude": longitudes,
+        },
+    )
+
+
+ds_ref = _make_test_dataset(
+    latitudes=np.array([45.0, 46.0, 47.0]),
+    longitudes=np.array([5.0, 6.0]),
+)
+
+ds_close = _make_test_dataset(
+    latitudes=np.array([45.005, 46.005, 47.005]),
+    longitudes=np.array([5.0, 6.0]),
+)
+
+ds_short = _make_test_dataset(
+    latitudes=np.array([45.0, 46.0]),
+    longitudes=np.array([5.0, 6.0]),
+)
+
+
+def test_align_lat_lon_single_dataset_returns_input():
+
+    aligned = align_lat_lon([ds_ref], coord="latitude")
+
+    assert len(aligned) == 1
+    assert aligned[0].identical(ds_ref)
+
+
+def test_align_lat_lon_aligns_close_coordinates():
+
+    aligned = align_lat_lon([ds_ref, ds_close], coord="latitude")
+
+    assert aligned[0]["latitude"].identical(ds_ref["latitude"])
+    assert aligned[1]["latitude"].identical(ds_ref["latitude"])
+
+
+def test_align_lat_lon_aligns_not_close_enough():
+
+    with pytest.raises(ValueError, match="seem to be too different"):
+        align_lat_lon([ds_ref, ds_close], coord="latitude", rel_tolerance=1e-6)
+
+
+def test_align_lat_lon_raises_when_coordinates_cannot_be_aligned():
+
+    ds_far = _make_test_dataset(
+        latitudes=np.array([45.5, 46.5, 47.5]),
+        longitudes=np.array([5.0, 6.0]),
+    )
+
+    with pytest.raises(ValueError, match="dimensions seem to be too different"):
+        align_lat_lon([ds_ref, ds_far], coord="latitude")
+
+
+def test_align_lat_lon_with_different_lengths():
+
+    align_lat_lon([ds_ref, ds_short], coord="latitude", min_rel_overlap=0.5)
+
+
+def test_align_lat_lon_with_too_different_lengths():
+
+    with pytest.raises(ValueError, match="cover too different ranges "):
+        align_lat_lon([ds_ref, ds_short], coord="latitude")

--- a/tests/operators/test_align.py
+++ b/tests/operators/test_align.py
@@ -50,7 +50,7 @@ def test_align_lat_lon_single_dataset_returns_input():
 
 def test_align_lat_lon_aligns_close_coordinates():
 
-    aligned = align_lat_lon([ds_ref, ds_close], coord="latitude")
+    aligned = align_lat_lon([ds_ref, ds_close], coord="latitude", rel_tolerance=0.01)
 
     assert aligned[0]["latitude"].identical(ds_ref["latitude"])
     assert aligned[1]["latitude"].identical(ds_ref["latitude"])
@@ -81,4 +81,4 @@ def test_align_lat_lon_with_different_lengths():
 def test_align_lat_lon_with_too_different_lengths():
 
     with pytest.raises(ValueError, match="cover too different ranges "):
-        align_lat_lon([ds_ref, ds_short], coord="latitude")
+        align_lat_lon([ds_ref, ds_short], coord="latitude", min_rel_overlap=0.8)


### PR DESCRIPTION
### Feature
Allow aligning latitude/longitude coordinates in cases where one model grid is a region cut out from the other model grid. When aligning grids, return only the subset of data that is covered by all models.

### Use case
This shall simplify the comparison of models that cover different regions.

### Other changes
Due to the `atol` argument in `np.allclose` when checking the alignment, the comparison of coordinates is less strict. Nothing should change for cases that did not lead to errors in the current version.

### New tuning parameters
This introduces a tolerance for the comparison of coordinates. Currently, this tolerance is hard-coded as 2e-4 degrees.