### PR TITLE
Add new plot of a posteriori covariance between countries

### DIFF
--- a/fluxie/plots/flux_country_covariance.py
+++ b/fluxie/plots/flux_country_covariance.py
@@ -10,10 +10,10 @@ def plot_flux_country_covariance(
     model_labels: dict[str, str] = {},
     cov_max: float = 0.5,
     cmap_diff: str = "coolwarm",
-) -> plt.Figure: 
+) -> plt.Figure:
     """
     Plot posterior country covariance for each model that provides variable 'covariance_flux_total_posterior_country'.
-    Only lower triangle of matrix plotted. Covariance is normalised before plotting. Values will range between -1 and 1. 
+    Only lower triangle of matrix plotted. Covariance is normalised before plotting. Values will range between -1 and 1.
 
     Args:
         ds_all (dictionary of datasets):
@@ -22,67 +22,92 @@ def plot_flux_country_covariance(
             Countries to be evaluated.
         model_labels (list):
             List of model_labels from fluxie.config.
-        cov_max (float, optional): 
+        cov_max (float, optional):
             Maximum value of covariance for colorbar. The colorbar will run from -cov_max to cov_max.
         cmap_diff (str, optional):
-            Colour map for flux difference plots.        
+            Colour map for flux difference plots.
 
     Returns:
         fig (figure):
             Plot of covariance matrix (lower triangle) for each model that provides covariance_flux_total_posterior_country.
-            
+
     """
-    
+
     # function for selecting only datasets with covariance variable
     def filter_cov(pair):
-        check_var='covariance_flux_total_posterior_country'
+        check_var = "covariance_flux_total_posterior_country"
         key, value = pair
         return check_var in value.data_vars
-    
 
-    # filter for datasets that contain covariance 
+    # filter for datasets that contain covariance
     ds = dict(filter(filter_cov, ds_all.items()))
-    
+
     # number of models required to decide on plot layout
     models = list(ds.keys())
     nn_models = len(ds)
-   
-    # start plot layout
-    fig, ax = plt.subplots(ncols=nn_models, figsize=(10, 10*nn_models))
-    fig.tight_layout()
-    for ii, mod in enumerate(ds): 
 
-        #  extract the data from each model 
+    # start plot layout
+    fig, ax = plt.subplots(ncols=nn_models, figsize=(10, 10 * nn_models))
+    fig.tight_layout()
+    for ii, mod in enumerate(ds):
+
+        #  extract the data from each model
         msk = range(0, len(ds[mod].country))
         if selected_countries is not None:
-            msk = [i for i, val in enumerate(ds[mod].country.values) if val in selected_countries]
-        cov = ds[mod].covariance_flux_total_posterior_country.mean(dim='time')[msk, msk]
+            msk = [
+                i
+                for i, val in enumerate(ds[mod].country.values)
+                if val in selected_countries
+            ]
+        cov = ds[mod].covariance_flux_total_posterior_country.mean(dim="time")[msk, msk]
         countries = ds[mod].country.values[msk]
         nn_country = len(countries)
 
         # normalise covariance (using variance on diagonal)
         dd = np.sqrt(np.diag(cov))
         tmp = np.repeat(dd, nn_country)
-        cov = cov / np.reshape(tmp, [nn_country, nn_country]) / np.reshape(tmp, [nn_country, nn_country], order='F')
+        cov = (
+            cov
+            / np.reshape(tmp, [nn_country, nn_country])
+            / np.reshape(tmp, [nn_country, nn_country], order="F")
+        )
         # construct matrix to hide upper triangle of matrix
         upper_mask = np.tri(cov.shape[0], cov.shape[1], k=-1)
-        upper_mask[upper_mask==0] = np.nan
+        upper_mask[upper_mask == 0] = np.nan
 
-        cov = cov*upper_mask
+        cov = cov * upper_mask
         # remove top row and rightmost column (no information contained)
-        cov = cov[1:nn_country,0:(nn_country-1)]
-        
+        cov = cov[1:nn_country, 0 : (nn_country - 1)]
+
         #  plot
-        im = ax[ii].imshow(cov, origin='upper', cmap=cmap_diff, vmin=-cov_max, vmax=cov_max)
-        ax[ii].xaxis.set_ticks(range(0,nn_country-1), countries[0:(nn_country-1)], rotation=45)
-        ax[ii].yaxis.set_ticks(range(0,nn_country-1), countries[1:nn_country], rotation=45)
-        ax[ii].spines['top'].set_visible(False)
-        ax[ii].spines['right'].set_visible(False)
-        ax[ii].set_title(model_labels[mod], fontsize='small')
+        im = ax[ii].imshow(
+            cov, origin="upper", cmap=cmap_diff, vmin=-cov_max, vmax=cov_max
+        )
+        ax[ii].xaxis.set_ticks(
+            range(0, nn_country - 1), countries[0 : (nn_country - 1)], rotation=45
+        )
+        ax[ii].yaxis.set_ticks(
+            range(0, nn_country - 1), countries[1:nn_country], rotation=45
+        )
+        ax[ii].spines["top"].set_visible(False)
+        ax[ii].spines["right"].set_visible(False)
+        ax[ii].set_title(model_labels[mod], fontsize="small")
 
     # add colorbar
-    period_str = ds[models[0]].time[0].dt.strftime("%Y").values+'-'+ds[models[0]].time[-1].dt.strftime("%Y").values  
-    add_colorbar(fig, ax[ii], im, 'both', 'Correlation (-)\n'+period_str, n_cbar=nn_models, idx_cbar=1, 
-            colorbar_type="row")
+    period_str = (
+        ds[models[0]].time[0].dt.strftime("%Y").values
+        + "-"
+        + ds[models[0]].time[-1].dt.strftime("%Y").values
+    )
+    add_colorbar(
+        fig,
+        ax[ii],
+        im,
+        "both",
+        "Correlation (-)\n" + period_str,
+        n_cbar=nn_models,
+        idx_cbar=1,
+        colorbar_type="row",
+    )
 
-    return(fig)
+    return fig

--- a/fluxie/plots/flux_country_covariance.py
+++ b/fluxie/plots/flux_country_covariance.py
@@ -48,7 +48,8 @@ def plot_flux_country_covariance(
     nn_models = len(ds)
    
     # start plot layout
-    fig, ax = plt.subplots(ncols=nn_models)
+    fig, ax = plt.subplots(ncols=nn_models, figsize=(10, 10*nn_models))
+    fig.tight_layout()
     for ii, mod in enumerate(ds): 
 
         #  extract the data from each model 

--- a/fluxie/plots/flux_country_covariance.py
+++ b/fluxie/plots/flux_country_covariance.py
@@ -1,7 +1,10 @@
+import logging
 import matplotlib.pyplot as plt
 import xarray as xr
 import numpy as np
 from fluxie.plots.utils import add_colorbar
+
+logger = logging.getLogger(__name__)
 
 
 def plot_flux_country_covariance(
@@ -19,7 +22,7 @@ def plot_flux_country_covariance(
         ds_all (dictionary of datasets):
             Dictionary of fluxes xarray datasets.
         selected_countries (list of str):
-            Countries to be evaluated.
+            Countries to be evaluated or None if all should be shown.
         model_labels (list):
             List of model_labels from fluxie.config.
         cov_max (float, optional):
@@ -45,10 +48,14 @@ def plot_flux_country_covariance(
     # number of models required to decide on plot layout
     models = list(ds.keys())
     nn_models = len(ds)
+    if nn_models==0:
+        logger.warn("No model contains posterior covariance. Skipping plot.")
+        return None
 
     # start plot layout
-    fig, ax = plt.subplots(ncols=nn_models, figsize=(10, 10 * nn_models))
+    fig, ax = plt.subplots(ncols=nn_models, figsize=(10, 10 * nn_models), squeeze=False)
     fig.tight_layout()
+    ax = ax.flatten()
     for ii, mod in enumerate(ds):
 
         #  extract the data from each model

--- a/fluxie/plots/flux_country_covariance.py
+++ b/fluxie/plots/flux_country_covariance.py
@@ -1,0 +1,87 @@
+import matplotlib.pyplot as plt
+import xarray as xr
+import numpy as np
+from fluxie.plots.utils import add_colorbar
+
+
+def plot_flux_country_covariance(
+    ds_all: dict[xr.Dataset],
+    selected_countries: list[str] = None,
+    model_labels: dict[str, str] = {},
+    cov_max: float = 0.5,
+    cmap_diff: str = "coolwarm",
+) -> plt.Figure: 
+    """
+    Plot posterior country covariance for each model that provides variable 'covariance_flux_total_posterior_country'.
+    Only lower triangle of matrix plotted. Covariance is normalised before plotting. Values will range between -1 and 1. 
+
+    Args:
+        ds_all (dictionary of datasets):
+            Dictionary of fluxes xarray datasets.
+        selected_countries (list of str):
+            Countries to be evaluated.
+        model_labels (list):
+            List of model_labels from fluxie.config.
+        cov_max (float, optional): 
+            Maximum value of covariance for colorbar. The colorbar will run from -cov_max to cov_max.
+        cmap_diff (str, optional):
+            Colour map for flux difference plots.        
+
+    Returns:
+        fig (figure):
+            Plot of covariance matrix (lower triangle) for each model that provides covariance_flux_total_posterior_country.
+            
+    """
+    
+    # function for selecting only datasets with covariance variable
+    def filter_cov(pair):
+        check_var='covariance_flux_total_posterior_country'
+        key, value = pair
+        return check_var in value.data_vars
+    
+
+    # filter for datasets that contain covariance 
+    ds = dict(filter(filter_cov, ds_all.items()))
+    
+    # number of models required to decide on plot layout
+    models = list(ds.keys())
+    nn_models = len(ds)
+   
+    # start plot layout
+    fig, ax = plt.subplots(ncols=nn_models)
+    for ii, mod in enumerate(ds): 
+
+        #  extract the data from each model 
+        msk = range(0, len(ds[mod].country))
+        if selected_countries is not None:
+            msk = [i for i, val in enumerate(ds[mod].country.values) if val in selected_countries]
+        cov = ds[mod].covariance_flux_total_posterior_country.mean(dim='time')[msk, msk]
+        countries = ds[mod].country.values[msk]
+        nn_country = len(countries)
+
+        # normalise covariance (using variance on diagonal)
+        dd = np.sqrt(np.diag(cov))
+        tmp = np.repeat(dd, nn_country)
+        cov = cov / np.reshape(tmp, [nn_country, nn_country]) / np.reshape(tmp, [nn_country, nn_country], order='F')
+        # construct matrix to hide upper triangle of matrix
+        upper_mask = np.tri(cov.shape[0], cov.shape[1], k=-1)
+        upper_mask[upper_mask==0] = np.nan
+
+        cov = cov*upper_mask
+        # remove top row and rightmost column (no information contained)
+        cov = cov[1:nn_country,0:(nn_country-1)]
+        
+        #  plot
+        im = ax[ii].imshow(cov, origin='upper', cmap=cmap_diff, vmin=-cov_max, vmax=cov_max)
+        ax[ii].xaxis.set_ticks(range(0,nn_country-1), countries[0:(nn_country-1)], rotation=45)
+        ax[ii].yaxis.set_ticks(range(0,nn_country-1), countries[1:nn_country], rotation=45)
+        ax[ii].spines['top'].set_visible(False)
+        ax[ii].spines['right'].set_visible(False)
+        ax[ii].set_title(model_labels[mod], fontsize='small')
+
+    # add colorbar
+    period_str = ds[models[0]].time[0].dt.strftime("%Y").values+'-'+ds[models[0]].time[-1].dt.strftime("%Y").values  
+    add_colorbar(fig, ax[ii], im, 'both', 'Correlation (-)\n'+period_str, n_cbar=nn_models, idx_cbar=1, 
+            colorbar_type="row")
+
+    return(fig)

--- a/fluxie/plots/flux_country_covariance.py
+++ b/fluxie/plots/flux_country_covariance.py
@@ -48,7 +48,7 @@ def plot_flux_country_covariance(
     # number of models required to decide on plot layout
     models = list(ds.keys())
     nn_models = len(ds)
-    if nn_models==0:
+    if nn_models == 0:
         logger.warn("No model contains posterior covariance. Skipping plot.")
         return None
 

--- a/scripts/example_basics.ipynb
+++ b/scripts/example_basics.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fluxy example\n",
+    "# Fluxie example\n",
     "\n",
-    "This notebook shows you basic usage of Fluxy using the test dataset."
+    "This notebook shows you basic usage of Fluxie using the test dataset."
    ]
   },
   {
@@ -174,10 +174,10 @@
    "source": [
     "#### Look at one dataset \n",
     "\n",
-    "Fluxy stores all the data in a dictionary of xarray datasets. One dataset for each model.\n",
+    "Fluxie stores all the data in a dictionary of xarray datasets. One dataset for each model.\n",
     "\n",
     "Below we show an example of how the data is stored internally.\n",
-    "Note that you don't need to understand much about xarray to use Fluxy."
+    "Note that you don't need to understand much about xarray to use Fluxie."
    ]
   },
   {
@@ -289,6 +289,31 @@
     "output_path = data_dir / 'flux_country.png'\n",
     "\n",
     "fig.savefig(output_path,bbox_inches='tight',pad_inches=0.2,dpi=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Posterior country covariance plot:\n",
+    "(not provided by all models)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fluxie.plots.flux_country_covariance import plot_flux_country_covariance\n",
+    "\n",
+    "selected_countries = ['DEU', 'BEL', 'NLD', 'LUX', 'FRA', 'GBR'] # None # List of countries to be evaluated or None to show all.\n",
+    "\n",
+    "fig = plot_flux_country_covariance(\n",
+    "    ds_all_flux_scaled,\n",
+    "    selected_countries = selected_countries, \n",
+    "    model_labels=model_labels,\n",
+    "    cov_max=0.5)"
    ]
   },
   {
@@ -693,7 +718,7 @@
    "source": [
     "## 3. Spatial maps of country/region fluxes\n",
     "\n",
-    "Spatial distribution and maps are always a hassle to plot, but Fluxy makes it easy."
+    "Spatial distribution and maps are always a hassle to plot, but Fluxie makes it easy."
    ]
   },
   {
@@ -872,7 +897,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Fluxy is a powerful tool to visualize and analyze flux data or timeseries.\n",
+    "Fluxie is a powerful tool to visualize and analyze flux data or timeseries.\n",
     "\n",
     "Try now to adapt it to your own data and see how it works!"
    ]


### PR DESCRIPTION
- called with dict of flux datasets
- selects only those models that provide posterior covariance as variable
- further selection of countries for which covariance should be displayed
- aggregation over time (mean)
- normalisation of covariance (all values between -1 and 1)
- plots only lower triangle of matrix