### PR TITLE
Fix tests for matplotlib v11

### DIFF
--- a/fluxie/operators/flux_prepare_inventory.py
+++ b/fluxie/operators/flux_prepare_inventory.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 
 from fluxie.operators.regions import extract_region_inventory_flux
 


### PR DESCRIPTION
A recent update of matplotlib has made the tests fail.

