### PR TITLE
Add alternative way to calculate posterior country uncertainty for aggregated regions

### DIFF
--- a/fluxie/operators/regions.py
+++ b/fluxie/operators/regions.py
@@ -183,9 +183,9 @@ def _extract_region_flux_sector(
                     (
                         (
                             ds_region[f"flux_{sector}_posterior_country"]
-                            - ds_region[f"percentile_flux_{sector}_posterior_country"].isel(
-                                percentile=min_percentile_index
-                            )
+                            - ds_region[
+                                f"percentile_flux_{sector}_posterior_country"
+                            ].isel(percentile=min_percentile_index)
                         )
                         ** 2
                     ).sum(dim="country")
@@ -195,7 +195,9 @@ def _extract_region_flux_sector(
                     f"Covariance matrix is not available for {m}. A posteriori uncertainty of {country} emissions based on uncorrelated uncertainty."
                 )
                 ds_region["sigma_posterior"] = np.sqrt(
-                    ((ds_region[f"stdev_flux_{sector}_posterior_country"]) ** 2).sum(dim="country")
+                    ((ds_region[f"stdev_flux_{sector}_posterior_country"]) ** 2).sum(
+                        dim="country"
+                    )
                 )
             else:
                 logger.warning(

--- a/fluxie/operators/regions.py
+++ b/fluxie/operators/regions.py
@@ -175,7 +175,28 @@ def _extract_region_flux_sector(
                     .sum(dim="country")
                     .sum(dim="country_2")
                 )
-
+            elif f"percentile_flux_{sector}_posterior_country" in ds_region.variables:
+                logger.warning(
+                    f"Covariance matrix is not available for {m}. A posteriori uncertainty of {country} emissions based on uncorrelated uncertainty."
+                )
+                ds_region["sigma_prior"] = np.sqrt(
+                    (
+                        (
+                            ds_region[f"flux_{sector}_posterior_country"]
+                            - ds_region[f"percentile_flux_{sector}_posterior_country"].isel(
+                                percentile=min_percentile_index
+                            )
+                        )
+                        ** 2
+                    ).sum(dim="country")
+                )
+            elif f"stdev_flux_{sector}_posterior_country" in ds_region.variables:
+                logger.warning(
+                    f"Covariance matrix is not available for {m}. A posteriori uncertainty of {country} emissions based on uncorrelated uncertainty."
+                )
+                ds_region["sigma_posterior"] = np.sqrt(
+                    ((ds_region[f"stdev_flux_{sector}_posterior_country"]) ** 2).sum(dim="country")
+                )
             else:
                 logger.warning(
                     f"Covariance matrix is not available for {m}. A posteriori uncertainty of {country} emissions will not be plotted."

--- a/fluxie/operators/regions.py
+++ b/fluxie/operators/regions.py
@@ -179,7 +179,7 @@ def _extract_region_flux_sector(
                 logger.warning(
                     f"Covariance matrix is not available for {m}. A posteriori uncertainty of {country} emissions based on uncorrelated uncertainty."
                 )
-                ds_region["sigma_prior"] = np.sqrt(
+                ds_region["sigma_posterior"] = np.sqrt(
                     (
                         (
                             ds_region[f"flux_{sector}_posterior_country"]


### PR DESCRIPTION
Currently, if no posterior covariance matrix is available for country-level emissions, fluxie sets posterior uncertainties to NA.

Alternatively, posterior percentiles or standard deviation can be used for the calculation of country posterior uncertainty (same way as it is done for prior uncertainty).

A warning is issued when posterior uncertainty is calculated without taking covariance into account.