### PR TITLE
Allow simultaneous plotting of prior/posterior stats

### DIFF
--- a/fluxie/operators/mf.py
+++ b/fluxie/operators/mf.py
@@ -10,6 +10,9 @@ from fluxie.operators.stats import stats_observed_vs_simulated
 logger = logging.getLogger(__name__)
 
 
+StatsType = Literal["prior", "posterior", "prior_above_BC", "posterior_above_BC"]
+
+
 def compute_mf_difference(
     ds_all: dict[str, xr.Dataset], models_to_subtract: list[str]
 ) -> dict[str, xr.Dataset]:
@@ -124,9 +127,7 @@ def compute_mf_difference(
 
 def stats_mf(
     ds_all: dict[str, dict],
-    stats_type: Literal[
-        "prior", "posterior", "prior_above_BC", "posterior_above_BC"
-    ] = "prior",
+    stats_type: StatsType | list[StatsType] = "prior",
     sites: list = None,
 ) -> pd.DataFrame:
     """
@@ -136,58 +137,71 @@ def stats_mf(
     This calls :py:func:`fluxie.operators.stats.stats_observed_vs_simulated`
 
     Args:
-        ds_all (dictionary of datasets):
+        ds_all:
             xarray datasets from slice_mf(), sliced between chosen dates
             but still containing all sites.
-        stats_type :
-            type of statistics to be computed. One of 'prior', 'posterior' for
+        stats_type:
+            type of statistics to be computed. Options are 'prior', 'posterior' for
             statistics on the absolute mole fractions and 'prior_above_BC',
             'posterior_above_BC' for regional part of mole fraction, i.e. with
             BC contribution subtracted from both observation and simulation.
-        sites: sites for which to make the stats.
+        sites:
+            sites for which to make the stats.
     Returns:
         stats (pandas.DataFrame):
             Dataframe containing the statistical measures.
     """
 
-    # assure that stats_type in allowed options
-    type_options = ["prior", "posterior", "prior_above_BC", "posterior_above_BC"]
-    assert stats_type in type_options, f"'{stats_type}' is not in {type_options}"
+    if isinstance(stats_type, str):
+        stats_type = [stats_type]
 
-    # select what to compare
-    if stats_type == "prior":
-        obs = "mf_observed"
-        sim = "mf_prior"
-    elif stats_type == "posterior":
-        obs = "mf_observed"
-        sim = "mf_posterior"
-    elif stats_type == "prior_above_BC":
-        obs = "mf_observed_no_bc_prior"
-        sim = "mf_prior_no_bc_prior"
-        ds_all = {
-            model: ds.assign(
-                mf_observed_no_bc_prior=ds["mf_observed"] - ds["mf_bc_prior"],
-                mf_prior_no_bc_prior=ds["mf_prior"] - ds["mf_bc_prior"],
-            )
-            for model, ds in ds_all.items()
-        }
-    elif stats_type == "posterior_above_BC":
-        obs = "mf_observed_no_bc_posterior"
-        sim = "mf_posterior_no_bc_posterior"
-        ds_all = {
-            model: ds.assign(
-                mf_observed_no_bc_posterior=ds["mf_observed"] - ds["mf_bc_posterior"],
-                mf_posterior_no_bc_posterior=ds["mf_posterior"] - ds["mf_bc_posterior"],
-            )
-            for model, ds in ds_all.items()
-        }
-    else:
-        # Should not happen due to the assert above
-        raise ValueError()
+    dfs = []
+    for stat in stats_type:
+        # assure that stats_type in allowed options
+        type_options = ["prior", "posterior", "prior_above_BC", "posterior_above_BC"]
+        assert stat in type_options, f"'{stat}' is not in {type_options}"
 
-    return stats_observed_vs_simulated(
-        ds_all,
-        obs_var=obs,
-        sim_var=sim,
-        sites=sites,
-    )
+        # select what to compare
+        if stat == "prior":
+            obs = "mf_observed"
+            sim = "mf_prior"
+        elif stat == "posterior":
+            obs = "mf_observed"
+            sim = "mf_posterior"
+        elif stat == "prior_above_BC":
+            obs = "mf_observed_no_bc_prior"
+            sim = "mf_prior_no_bc_prior"
+            ds_all = {
+                model: ds.assign(
+                    mf_observed_no_bc_prior=ds["mf_observed"] - ds["mf_bc_prior"],
+                    mf_prior_no_bc_prior=ds["mf_prior"] - ds["mf_bc_prior"],
+                )
+                for model, ds in ds_all.items()
+            }
+        elif stat == "posterior_above_BC":
+            obs = "mf_observed_no_bc_posterior"
+            sim = "mf_posterior_no_bc_posterior"
+            ds_all = {
+                model: ds.assign(
+                    mf_observed_no_bc_posterior=ds["mf_observed"]
+                    - ds["mf_bc_posterior"],
+                    mf_posterior_no_bc_posterior=ds["mf_posterior"]
+                    - ds["mf_bc_posterior"],
+                )
+                for model, ds in ds_all.items()
+            }
+        else:
+            # Should not happen due to the assert above
+            raise ValueError()
+
+        df = stats_observed_vs_simulated(
+            ds_all,
+            obs_var=obs,
+            sim_var=sim,
+            stats_type=stat,
+            sites=sites,
+        )
+
+        dfs.append(df)
+
+    return pd.concat(dfs, ignore_index=True)

--- a/fluxie/operators/mf.py
+++ b/fluxie/operators/mf.py
@@ -3,7 +3,7 @@ import xarray as xr
 import pandas as pd
 import logging
 from fluxie.operators.convert import get_variables
-from typing import Literal
+from typing import Literal, get_args
 
 from fluxie.operators.stats import stats_observed_vs_simulated
 
@@ -158,8 +158,7 @@ def stats_mf(
     dfs = []
     for stat in stats_type:
         # assure that stats_type in allowed options
-        type_options = ["prior", "posterior", "prior_above_BC", "posterior_above_BC"]
-        assert stat in type_options, f"'{stat}' is not in {type_options}"
+        assert stat in get_args(StatsType), f"'{stat}' is not in {get_args(StatsType)}"
 
         # select what to compare
         if stat == "prior":

--- a/fluxie/operators/stats.py
+++ b/fluxie/operators/stats.py
@@ -9,8 +9,8 @@ def stats_observed_vs_simulated(
     ds_all: dict[str, dict],
     obs_var: str,
     sim_var: str,
-    sites: list = None,
-    stats_type: str = "Undefined",
+    sites: list[str] | None = None,
+    stats_type: str | None = None,
 ) -> pd.DataFrame:
     """
     Calculates multiple statistical measures of the fit between the observed
@@ -31,8 +31,10 @@ def stats_observed_vs_simulated(
             Name of the observed variable.
         sim_var (str):
             Name of the simulated variable.
-        sites (list):
+        sites (list of str):
             Sites for which to make the stats.
+        stats_type (str):
+            Type of data statistics being evaluated (see StatsType in fluxie.operators.mf).
 
     Returns:
         stats (pandas.DataFrame):

--- a/fluxie/operators/stats.py
+++ b/fluxie/operators/stats.py
@@ -10,6 +10,7 @@ def stats_observed_vs_simulated(
     obs_var: str,
     sim_var: str,
     sites: list = None,
+    stats_type: str = "Undefined",
 ) -> pd.DataFrame:
     """
     Calculates multiple statistical measures of the fit between the observed
@@ -38,6 +39,7 @@ def stats_observed_vs_simulated(
             Statistical measures, for each site and for each model between observations and
             simulations. Columns:
                 * 'model': model string
+                * 'stats_type' : data being evaluated (see StatsType in fluxie.operators.mf)
                 * 'site': observation platform ID
                 * 'pearson': Pearson correlation coefficient
                 * 'mae': mean absolute error
@@ -111,6 +113,7 @@ def stats_observed_vs_simulated(
             # calculate stats
             stats_site = {
                 "model": model,
+                "stats_type": stats_type,
                 "site": site,
                 "pearson": np.corrcoef(obs, sim)[0, 1],
                 "rmse": np.sqrt(np.mean((sim - obs) ** 2)),

--- a/fluxie/plots/mf_stats.py
+++ b/fluxie/plots/mf_stats.py
@@ -208,10 +208,11 @@ def plot_stats_mf(
     model_labels: dict[str, str],
     config_data: dict[dict],
     mf_units_print: str,
-    stats_type: str,
+    stats_type: str | list[str],
     stats_ylim: dict[list] = None,
     start_date: str = None,
     end_date: str = None,
+    top_to_bottom_align: bool = True,
 ) -> Figure:
     """
     Plots statistics for all sites, for all models.
@@ -232,13 +233,16 @@ def plot_stats_mf(
             Use json filenames as keys.
         mf_units_print (str):
             Mole fraction units used in plots
-        stats_type (str):
+        stats_type (str or list of str):
             Type of statistics to be plotted. Should be the same as used in call to stats_mf().
         stats_ylim (dict of lists):
             Limits for y-axis of individual statistic plots. Can be given for selected
             statistics only or passed as None for automatic axis range.
         start_date (str) and end_date (str):
             Dates used to title the plot.
+        top_to_bottom_align (bool):
+            If True, subfigures are vertically displayed.
+            Otherwise, they are placed side by side.
     Returns:
         fig (figure):
             Plot showing each model's fit statistics, for each site.
@@ -246,24 +250,69 @@ def plot_stats_mf(
 
     models = np.unique(stats["model"].to_numpy())
     # make sure model_labels are in the correct order
-    model_str = [model_labels[k] for k in models]
-    # plot colors from model names
-    colors = [model_colors[k][0] for k in models]
+    plot_model_labels = [model_labels[k] for k in models]
 
-    # determine strings used for plot subtitle
-    stats_str = stats_type
+    if isinstance(stats_type, str):
+        stats_type = [stats_type]
+
+    # determine strings used for plot subtitle and labels
+    stats_str = ""
     mf_str = ""
-    if stats_type not in ["prior", "posterior"]:
-        mf_str = " above BC"
-        stats_str = stats_type.split("_")[0]
+    add_gap = False
+    if len(stats_type) == 1:
+        stats_str = " " + stats_type[0]
+        plot_label = plot_model_labels
+        if "above_BC" in stats_str:
+            mf_str = " above BC"
+            stats_str = stats_str.split("_")[0]
+    else:
+        add_gap = True
+        plot_label = [
+            model + " " + stat.replace("_", " ")
+            for model in plot_model_labels
+            for stat in stats_type
+        ]
 
-    long_stats = pd.melt(stats, id_vars=["model", "site"], value_vars=stats_to_plot)
-    nrows = len(stats_to_plot)
-    fig, ax = plt.subplots(nrows, 1, figsize=(10, 3 * nrows), tight_layout=True)
+    # create subplots
+    nstats = len(stats_to_plot)
+    if top_to_bottom_align:
+        nrows = nstats
+        ncolumns = 1
+        plot_width = 10
+        plot_height = 3 * nstats
+        leg_yloc = 0.94
+    else:
+        nrows = 1
+        ncolumns = nstats
+        plot_width = 3 * nstats
+        plot_height = 4
+        leg_yloc = 0.875
+    fig, ax = plt.subplots(
+        nrows, ncolumns, figsize=(plot_width, plot_height), tight_layout=True
+    )
+
+    long_stats = pd.melt(
+        stats, id_vars=["model", "stats_type", "site"], value_vars=stats_to_plot
+    )
     for i, stat in enumerate(stats_to_plot):
         df_this_stats = long_stats[long_stats["variable"] == stat].pivot(
-            index="site", columns="model", values="value"
+            index="site", columns=["model", "stats_type"], values="value"
         )
+
+        # Add dummy rows (used as space between model bars)
+        if add_gap:
+            for model in models:
+                df_this_stats[(model, "gap")] = 0
+
+        # Order rows per model (so that all stats from the same model are plotted first)
+        all_stats_type = df_this_stats.columns.get_level_values("stats_type").unique()
+        df_columns = [(model, stat) for model in models for stat in all_stats_type]
+        colors = [
+            model_colors[k][0] if "posterior" in stat else model_colors[k][1]
+            for k in models
+            for stat in all_stats_type
+        ]
+        df_this_stats = df_this_stats[df_columns]
 
         df_this_stats.plot(
             kind="bar",
@@ -284,20 +333,28 @@ def plot_stats_mf(
             ylabel = ylabel + " (" + mf_units_print + ")"
         ax[i].set_ylabel(ylabel)
 
-    leg = ax[0].legend(
+    # Remove dummy column from handles
+    handles, _ = ax[0].get_legend_handles_labels()
+    real_handles = [
+        handle for handle, col in zip(handles, df_columns) if col[1] != "gap"
+    ]
+
+    leg = fig.legend(
+        handles=real_handles,
         ncol=3,
         borderpad=0.2,
         columnspacing=1.0,
         loc="upper center",
-        bbox_to_anchor=(0.5, 1.25),
-        labels=model_str,
+        bbox_to_anchor=(0.5, leg_yloc),
+        labels=plot_label,
     )
 
     species_info = config_data["species_info"][species]
+    end_space = "\n" if len(plot_label) <= 3 else "\n\n"
     fig.suptitle(
         (
-            f'{species_info["species_print"]} {stats_str} model performance versus mole fraction observations{mf_str}'
-            f"\n{start_date} to {end_date}"
+            f'{species_info["species_print"]}{stats_str} model performance versus mole fraction observations{mf_str}'
+            f"\n{start_date} to {end_date}{end_space}"
         )
     )
 

--- a/fluxie/plots/mf_stats.py
+++ b/fluxie/plots/mf_stats.py
@@ -284,7 +284,7 @@ def plot_stats_mf(
     else:
         nrows = 1
         ncolumns = nstats
-        plot_width = 3 * nstats
+        plot_width = 4 * nstats
         plot_height = 4
         leg_yloc = 0.875
     fig, ax = plt.subplots(
@@ -322,6 +322,7 @@ def plot_stats_mf(
             xlabel="",
             legend=False,
             zorder=3,
+            width=0.8,
         )
         ax[i].grid(zorder=0)
         if stats_ylim is not None:

--- a/scripts/PARIS_inversion_results.ipynb
+++ b/scripts/PARIS_inversion_results.ipynb
@@ -635,7 +635,7 @@
     "what_to_compare = 'posterior_above_BC'\n",
     "stats_ylim = {\"pearson\": [0,1], \"bias\": [-1.5,0.5], \"crmse\": [0,1.5] }    # or set it to None\n",
     "get_labels_from_file = True # If False, uses default labels. If True, uses labels from config file.\n",
-    "\n",
+    "top_to_bottom_align = True\n",
     "\n",
     "### Implemented statistics (stats_to_plot)\n",
     "# pearson - Pearson correlation coefficient\n",
@@ -671,7 +671,8 @@
     "                    stats_type=what_to_compare,\n",
     "                    stats_ylim=stats_ylim,\n",
     "                    start_date=start_date, \n",
-    "                    end_date=end_date)"
+    "                    end_date=end_date,\n",
+    "                    top_to_bottom_align=top_to_bottom_align)"
    ]
   },
   {


### PR DESCRIPTION
- function "stats_mf" now accepts `stats_type` to be a list of strings instead of one single string. The diff does not show up very nicely: I have basically moved everything inside a for loop over the elements of `stats_type` and appended the data frames.
- variable `stats_type` is now a column in the dataframe created in function "stats_observed_vs_simulated".
- plotting function "plot_stats_mf" was updated accordingly.
- option to arrange subplots  horizontally was also added.